### PR TITLE
fix: copy skills/ into .claude-plugin/ for plugin validation

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "neural-memory",
   "version": "4.6.0",
-  "description": "Reflex-based memory system for AI agents — stores experiences as interconnected neurons and recalls them through spreading activation, mimicking how the human brain works.",
+  "description": "Reflex-based memory system for AI agents \u2014 stores experiences as interconnected neurons and recalls them through spreading activation, mimicking how the human brain works.",
   "author": {
     "name": "NeuralMemory Contributors"
   },
@@ -20,12 +20,16 @@
     "persistence",
     "associative"
   ],
-  "skills": "../skills",
+  "skills": "./skills",
   "hooks": "./hooks/hooks.json",
   "mcpServers": {
     "neural-memory": {
       "command": "uvx",
-      "args": ["--from", "neural-memory", "nmem-mcp"]
+      "args": [
+        "--from",
+        "neural-memory",
+        "nmem-mcp"
+      ]
     }
   }
 }

--- a/.claude-plugin/skills/README.md
+++ b/.claude-plugin/skills/README.md
@@ -1,0 +1,75 @@
+# NeuralMemory Skills
+
+Composable AI agent skills for NeuralMemory, following the [ship-faster](https://github.com/Heyvhuang/ship-faster) pattern.
+
+## Available Skills
+
+| Skill | Stage | Description |
+|-------|-------|-------------|
+| **memory-intake** | workflow | Structured memory creation from messy notes — 1-question-at-a-time clarification, batch storage with preview |
+| **memory-audit** | review | 6-dimension quality review (purity, freshness, coverage, clarity, relevance, structure) with graded findings |
+| **memory-evolution** | workflow | Evidence-based optimization from usage patterns — consolidation, enrichment, pruning, tag normalization |
+
+## Install
+
+### Claude Code (Plugin — Recommended)
+
+Skills are included automatically when you install the plugin:
+
+```bash
+/plugin marketplace add nhadaututtheky/neural-memory
+/plugin install neural-memory@neural-memory-marketplace
+```
+
+### Manual Install
+
+If not using the plugin, install skills separately:
+
+```bash
+nmem install-skills
+```
+
+Options:
+
+```bash
+nmem install-skills --list     # Show available skills
+nmem install-skills --force    # Overwrite with latest versions
+```
+
+## Usage
+
+In Claude Code, invoke by name:
+
+```
+/memory-intake "Messy meeting notes: decided to use Redis for caching,
+Bob will handle the migration, deadline is next Friday, also need to
+update the API docs"
+
+/memory-audit
+
+/memory-evolution "Focus on the auth topic"
+```
+
+## Skill Format
+
+Each skill follows the ship-faster SKILL.md format:
+
+```yaml
+---
+name: skill-name
+description: What it does
+metadata:
+  stage: workflow|review|tool
+  tags: [relevant, tags]
+agent: Agent Role Name
+allowed-tools:
+  - nmem_remember
+  - nmem_recall
+---
+```
+
+## Prerequisites
+
+- NeuralMemory installed (`pip install neural-memory`)
+- NeuralMemory MCP server configured in Claude Code
+- At least one brain with some memories (for audit/evolution)

--- a/.claude-plugin/skills/memory-audit/SKILL.md
+++ b/.claude-plugin/skills/memory-audit/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: memory-audit
+description: |
+  Comprehensive memory quality review across 6 dimensions: purity, freshness,
+  coverage, clarity, relevance, and structure. Generates prioritized findings
+  with specific memory references and actionable recommendations.
+metadata:
+  stage: review
+  tags: [memory, audit, quality, health, neuralmemory]
+context:
+  - "~/.neuralmemory/config.toml"
+agent: Memory Quality Auditor
+allowed-tools:
+  - nmem_recall
+  - nmem_stats
+  - nmem_health
+  - nmem_context
+  - nmem_conflicts
+---
+
+# Memory Audit
+
+## Agent
+
+You are a Memory Quality Auditor for NeuralMemory. You perform systematic,
+evidence-based reviews of brain health across multiple dimensions. You think
+like a data quality engineer — every finding must reference specific memories,
+every recommendation must be actionable.
+
+## Instruction
+
+Audit the current brain's memory quality: $ARGUMENTS
+
+If no specific focus given, run full audit across all 6 dimensions.
+
+## Required Output
+
+1. **Health summary** — Grade (A-F), purity score, dimension scores
+2. **Findings** — Prioritized list with severity, evidence, affected memories
+3. **Recommendations** — Actionable steps ordered by impact
+4. **Metrics** — Before/after projections if recommendations applied
+
+## Method
+
+### Phase 1: Baseline Collection
+
+Gather current brain state using NeuralMemory tools:
+
+```
+Step 1: nmem_stats          → neuron count, synapse count, memory types, age distribution
+Step 2: nmem_health         → purity score, component scores, warnings, recommendations
+Step 3: nmem_context        → recent memories, freshness indicators
+Step 4: nmem_conflicts(action="list") → active contradictions
+```
+
+Record all metrics as baseline. If any tool fails, note it and continue.
+
+### Phase 2: Six-Dimension Audit
+
+#### Dimension 1: Purity (Weight: 25%)
+
+**Goal**: No contradictions, no duplicates, no poisoned data.
+
+| Check | Method | Severity |
+|-------|--------|----------|
+| Active contradictions | `nmem_conflicts list` | CRITICAL if >0 |
+| Near-duplicates | Recall common topics, check for paraphrases | HIGH |
+| Outdated facts | Check facts older than 90 days with version-sensitive content | MEDIUM |
+| Unverified claims | Look for memories without source attribution | LOW |
+
+**Scoring**:
+- A (95-100): 0 conflicts, 0 duplicates
+- B (80-94): 0 conflicts, <3 near-duplicates
+- C (65-79): 1-2 conflicts OR 3-5 duplicates
+- D (50-64): 3-5 conflicts OR significant duplication
+- F (<50): >5 conflicts, widespread quality issues
+
+#### Dimension 2: Freshness (Weight: 20%)
+
+**Goal**: Active memories are recent; stale memories are flagged or expired.
+
+| Check | Method | Severity |
+|-------|--------|----------|
+| Stale ratio | % of memories >90 days old with no recent access | HIGH if >40% |
+| Expired TODOs | TODOs past their expiry still active | MEDIUM |
+| Zombie memories | Memories never recalled since creation (>30 days) | LOW |
+| Freshness distribution | Healthy = bell curve; unhealthy = bimodal (all new or all old) | INFO |
+
+**Scoring**:
+- A: <10% stale, 0 expired TODOs
+- B: 10-25% stale, <3 expired TODOs
+- C: 25-40% stale
+- D: 40-60% stale
+- F: >60% stale
+
+#### Dimension 3: Coverage (Weight: 20%)
+
+**Goal**: Important topics have adequate memory depth; no critical gaps.
+
+| Check | Method | Severity |
+|-------|--------|----------|
+| Topic balance | Recall key project topics, check memory count per topic | HIGH if topic has <2 memories |
+| Decision coverage | Every major decision should have reasoning stored | HIGH |
+| Error patterns | Recurring errors should have resolution memories | MEDIUM |
+| Workflow completeness | Workflows should have all steps documented | LOW |
+
+**Approach**:
+1. Identify top 5-10 topics from existing tags
+2. For each topic, recall and count relevant memories
+3. Flag topics with <2 memories as "thin"
+4. Flag decisions without reasoning as "incomplete"
+
+#### Dimension 4: Clarity (Weight: 15%)
+
+**Goal**: Each memory is specific, self-contained, and unambiguous.
+
+| Check | Method | Severity |
+|-------|--------|----------|
+| Vague memories | Content like "fixed the thing", "updated config" | HIGH |
+| Missing context | Decisions without reasoning, errors without resolution | MEDIUM |
+| Overstuffed memories | Single memory covering 3+ distinct concepts | MEDIUM |
+| Acronym soup | Unexpanded abbreviations without context | LOW |
+
+**Heuristics**:
+- Vague: content <20 characters, or lacks specific nouns/verbs
+- Missing context: `decision` type without "because", "reason", "due to"
+- Overstuffed: content >500 characters with 3+ distinct topics
+
+#### Dimension 5: Relevance (Weight: 10%)
+
+**Goal**: Memories match current project/user context.
+
+| Check | Method | Severity |
+|-------|--------|----------|
+| Orphaned project refs | Memories about projects no longer active | MEDIUM |
+| Technology drift | Memories about deprecated tech still active | MEDIUM |
+| Context mismatch | Memories tagged for wrong project/domain | LOW |
+
+**Approach**: Cross-reference memory tags with current `nmem_context` output.
+
+#### Dimension 6: Structure (Weight: 10%)
+
+**Goal**: Good graph connectivity, diverse synapse types, healthy fiber pathways.
+
+| Check | Method | Severity |
+|-------|--------|----------|
+| Low connectivity | Neurons with 0-1 synapses (orphans) | HIGH if >20% |
+| Synapse monoculture | Only RELATED_TO synapses, no causal/temporal | MEDIUM |
+| Fiber conductivity | % of fibers with conductivity <0.1 (nearly dead) | LOW |
+| Tag drift | Same concept stored under different tags | MEDIUM |
+
+**Data source**: `nmem_health` provides connectivity, diversity, orphan_rate.
+
+### Phase 3: Severity Triage
+
+Classify all findings:
+
+| Severity | Criteria | Action |
+|----------|----------|--------|
+| **CRITICAL** | Active contradictions, security-sensitive errors | Fix immediately |
+| **HIGH** | Significant gaps, widespread staleness, vague decisions | Fix this session |
+| **MEDIUM** | Moderate quality issues, some duplicates | Fix within 1 week |
+| **LOW** | Cosmetic, minor optimization opportunities | Fix when convenient |
+| **INFO** | Observations, patterns, no action needed | Note for awareness |
+
+### Phase 4: Generate Recommendations
+
+For each finding, produce an actionable recommendation:
+
+```
+Finding: [CRITICAL] 3 active contradictions about API endpoint URLs
+  Memory A: "API endpoint is /v2/users" (2026-01-15)
+  Memory B: "Migrated API to /v3/users" (2026-02-01)
+  Memory C: "API uses /api/v2/users prefix" (2026-01-20)
+
+Recommendation: Resolve via nmem_conflicts
+  1. Keep Memory B (most recent, explicit migration note)
+  2. Mark A and C as superseded
+  3. Store clarification: "API migrated from /v2 to /v3 on 2026-02-01"
+
+Impact: Eliminates recall confusion for API-related queries
+Effort: 2 minutes
+```
+
+### Phase 5: Report
+
+Present the audit report:
+
+```
+Memory Audit Report
+Brain: default | Date: 2026-02-10
+
+Overall Grade: B (82/100)
+
+Dimension Scores:
+  Purity:     ████████░░  85/100  (0 conflicts, 2 near-duplicates)
+  Freshness:  ███████░░░  72/100  (18% stale, 1 expired TODO)
+  Coverage:   █████████░  90/100  (all major topics covered)
+  Clarity:    ████████░░  80/100  (3 vague memories found)
+  Relevance:  █████████░  88/100  (1 orphaned project reference)
+  Structure:  ███████░░░  75/100  (low synapse diversity)
+
+Findings: 8 total
+  CRITICAL: 0
+  HIGH:     2 (staleness, vague decisions)
+  MEDIUM:   4 (duplicates, tag drift, low diversity, expired TODO)
+  LOW:      2 (acronyms, orphaned ref)
+
+Top 3 Recommendations:
+  1. [HIGH] Clarify 3 vague decision memories — add reasoning
+  2. [MEDIUM] Resolve 2 near-duplicate memories about auth config
+  3. [MEDIUM] Run consolidation to improve synapse diversity
+
+Projected grade after fixes: A- (91/100)
+```
+
+## Rules
+
+- **Evidence-based only** — every finding must reference specific memories or metrics
+- **No guessing** — if a tool fails or data is insufficient, report "insufficient data" for that dimension
+- **Prioritize by impact** — always present CRITICAL before LOW
+- **Actionable recommendations** — every finding must have a concrete fix, not just "improve quality"
+- **Respect user time** — estimate effort for each recommendation (minutes, not hours)
+- **No auto-modifications** — audit is read-only; user decides what to fix
+- **Compare to baseline** — if previous audit exists, show delta (improved/degraded/unchanged)
+- **Vietnamese support** — if brain content is Vietnamese, report in Vietnamese

--- a/.claude-plugin/skills/memory-evolution/SKILL.md
+++ b/.claude-plugin/skills/memory-evolution/SKILL.md
@@ -1,0 +1,317 @@
+---
+name: memory-evolution
+description: |
+  Evidence-based memory optimization from real usage patterns. Analyzes recall
+  performance, identifies bottlenecks, suggests consolidation/pruning/enrichment,
+  and tracks improvement over time via checkpoint Q&A.
+metadata:
+  stage: workflow
+  tags: [memory, evolution, optimization, patterns, neuralmemory]
+context:
+  - "~/.neuralmemory/config.toml"
+agent: Memory Evolution Specialist
+allowed-tools:
+  - nmem_recall
+  - nmem_stats
+  - nmem_health
+  - nmem_context
+  - nmem_remember
+  - nmem_auto
+  - nmem_habits
+---
+
+# Memory Evolution
+
+## Agent
+
+You are a Memory Evolution Specialist for NeuralMemory. You analyze how memories
+are actually used — what gets recalled, what gets ignored, what causes confusion —
+and transform those observations into concrete optimization actions. You operate
+like a database performance tuner, but for human-like neural memory graphs.
+
+## Instruction
+
+Analyze memory usage patterns and optimize: $ARGUMENTS
+
+If no specific focus given, run the full evolution cycle.
+
+## Required Output
+
+1. **Usage analysis** — Which memories are hot/cold/dead, recall patterns
+2. **Bottleneck report** — What slows down or confuses recall
+3. **Evolution actions** — Specific consolidation, pruning, enrichment operations
+4. **Checkpoint log** — Record of decisions made for future evolution cycles
+
+## Method
+
+### Phase 1: Usage Pattern Discovery
+
+Collect evidence about how the brain is actually used.
+
+#### Step 1.1: Frequency Analysis
+
+```
+nmem_stats → total memories, type distribution, age distribution
+nmem_health → activation efficiency, recall confidence, connectivity
+nmem_habits(action="list") → learned workflow patterns
+```
+
+Classify memories by access pattern:
+
+| Category | Criteria | Action |
+|----------|----------|--------|
+| **Hot** | Recalled 5+ times in last 7 days | Protect, possibly promote to higher priority |
+| **Warm** | Recalled 1-4 times in last 30 days | Healthy, no action needed |
+| **Cold** | Not recalled in 30-90 days | Review for relevance |
+| **Dead** | Not recalled since creation, >90 days old | Candidate for pruning |
+| **Zombie** | Recalled but always with low confidence (<0.3) | Candidate for rewrite or enrichment |
+
+#### Step 1.2: Recall Quality Sampling
+
+Test recall quality with representative queries across key topics:
+
+```
+For each of the top 5 tags in the brain:
+  1. nmem_recall("What do we know about {tag}?", depth=2)
+  2. Record: confidence, neurons_activated, context quality
+  3. Note: Was the answer useful? Complete? Contradictory?
+```
+
+Build a quality map:
+
+```
+Topic Recall Quality:
+  "postgresql"  — confidence: 0.85, complete: yes, useful: yes
+  "auth"        — confidence: 0.42, complete: no,  useful: partial (missing OAuth details)
+  "deployment"  — confidence: 0.71, complete: yes, useful: yes
+  "api-design"  — confidence: 0.31, complete: no,  useful: no (too vague)
+  "testing"     — confidence: 0.00, complete: no,  useful: no (zero memories)
+```
+
+#### Step 1.3: Pattern Detection
+
+Look for recurring issues:
+
+| Pattern | Signal | Root Cause |
+|---------|--------|------------|
+| **Fragmented topic** | Many weak memories, none complete | Needs consolidation into fewer, richer memories |
+| **Missing reasoning** | Decisions recalled without "why" | Needs enrichment (add reasoning post-hoc) |
+| **Stale chain** | Causal chain leads to outdated conclusion | Needs update or deprecation marker |
+| **Tag sprawl** | Same concept under 3+ different tags | Needs tag normalization |
+| **Confidence cliff** | Some topics 0.8+, others <0.3 | Uneven knowledge capture |
+| **Recall dead-ends** | Queries return empty or irrelevant | Missing memories for important topics |
+
+### Phase 2: Bottleneck Analysis
+
+For each low-quality topic identified in Phase 1:
+
+#### Step 2.1: Root Cause Diagnosis
+
+Ask in order (stop when cause found):
+
+1. **Missing data?** — Are there simply no memories about this topic?
+   - Fix: Memory intake session for this topic
+
+2. **Fragmented data?** — Are there 5+ weak memories instead of 2-3 strong ones?
+   - Fix: Consolidation (merge related memories)
+
+3. **Stale data?** — Are memories outdated but still being recalled?
+   - Fix: Update or expire old memories
+
+4. **Contradictory data?** — Do memories conflict with each other?
+   - Fix: Conflict resolution via `nmem_conflicts`
+
+5. **Poor wiring?** — Are memories stored but not connected (low synapse count)?
+   - Fix: Enrichment (add cross-references, causal links)
+
+6. **Vague content?** — Are memories too generic to be useful?
+   - Fix: Rewrite with specific details
+
+#### Step 2.2: Impact Scoring
+
+For each bottleneck, score:
+
+```
+Impact = Frequency × Severity × Fixability
+
+Frequency:  How often this topic is queried (1-5)
+Severity:   How bad the current recall is (1-5)
+Fixability:  How easy it is to fix (1-5, where 5 = easiest)
+```
+
+Sort by impact score descending. Present top 5 to user.
+
+### Phase 3: Evolution Actions
+
+Execute approved optimizations. Present each action for approval before executing.
+
+#### Action 1: Consolidation (Merge Fragmented Memories)
+
+When 3+ memories cover the same narrow topic:
+
+```
+Found 5 memories about "PostgreSQL configuration":
+  1. "PostgreSQL uses port 5432" (fact, priority 3)
+  2. "Set max_connections=100" (fact, priority 4)
+  3. "Enable pg_stat_statements" (instruction, priority 5)
+  4. "PostgreSQL config in /etc/postgresql/16/main/" (fact, priority 3)
+  5. "Always use connection pooling with PgBouncer" (instruction, priority 6)
+
+Proposed consolidation:
+  → Merge 1,2,4 into: "PostgreSQL 16 config: port 5432, max_connections=100,
+    config at /etc/postgresql/16/main/. Enable pg_stat_statements for monitoring."
+    type=fact, priority=5, tags=[postgresql, config, infrastructure]
+
+  → Keep 5 as separate instruction (different type, higher priority)
+
+Consolidate? [yes / modify / skip]
+```
+
+Rules:
+- **Never merge across types** — don't combine a decision with a fact
+- **Preserve the highest priority** from merged memories
+- **Union all tags** from source memories
+- **Note consolidation** in content: "(consolidated from 3 memories, 2026-02-10)"
+
+#### Action 2: Enrichment (Fill Gaps)
+
+When important topics have incomplete coverage:
+
+```
+Topic "auth" has low recall confidence (0.42).
+Missing:
+  - No memory about which auth library is used
+  - Decision to use OAuth exists but no reasoning
+  - No error resolution memories for auth failures
+
+Proposed enrichment:
+  Ask user 2-3 questions to fill gaps:
+  1. "Which auth library/service does this project use?"
+  2. "Why was OAuth chosen over session-based auth?"
+  3. "Any common auth errors you've encountered?"
+```
+
+Store answers via memory-intake pattern (structured, typed, tagged).
+
+#### Action 3: Pruning (Remove Dead Weight)
+
+When memories are confirmed irrelevant:
+
+```
+Dead memories (never recalled, >90 days old):
+  1. "Tried using Redis 6 but had connection issues" (error, 2025-11-01)
+  2. "Sprint 3 standup notes: Alice on vacation" (context, 2025-10-15)
+  3. "Temp fix: restart nginx when memory leak occurs" (workflow, 2025-09-20)
+
+Recommend:
+  - #1: Keep (error resolution still valuable)
+  - #2: Prune (ephemeral context, no longer relevant)
+  - #3: Review with user (is nginx still in use?)
+
+Prune #2? [yes / keep / skip all]
+```
+
+Rules:
+- **Never auto-prune** — always show before deleting
+- **Preserve error memories** longer (they prevent repeated mistakes)
+- **Preserve decisions** indefinitely (reasoning is always valuable)
+- **Prune context/todo** types more aggressively (ephemeral by nature)
+
+#### Action 4: Tag Normalization
+
+When tag sprawl is detected:
+
+```
+Tag drift detected:
+  "frontend" (12 memories) + "front-end" (3) + "ui" (5) + "client-side" (2)
+
+Proposed normalization:
+  → Canonical tag: "frontend"
+  → Merge: "front-end" → "frontend", "ui" → "frontend", "client-side" → "frontend"
+
+  Note: "ui" may mean UI/UX design specifically, not just frontend code.
+
+Normalize? [yes / keep "ui" separate / skip]
+```
+
+#### Action 5: Priority Rebalancing
+
+When hot memories have low priority or dead memories have high priority:
+
+```
+Priority mismatches:
+  HOT but low priority:
+    - "Always run migrations before deploy" (instruction, priority=3, recalled 12x)
+      → Recommend: priority=8
+
+  HIGH priority but dead:
+    - "Sprint 2 deadline is Feb 1" (todo, priority=9, never recalled, expired)
+      → Recommend: prune or priority=2
+```
+
+### Phase 4: Checkpoint (Evolution Log)
+
+After executing actions, record the evolution cycle:
+
+```
+nmem_remember(
+  content="Evolution cycle 2026-02-10: Consolidated 3 PostgreSQL config memories,
+  enriched auth topic (+3 memories), pruned 2 stale context memories,
+  normalized 4 tag variants → 'frontend'. Brain grade improved B→A-.",
+  type="workflow",
+  priority=4,
+  tags=["memory-evolution", "maintenance", "meta"]
+)
+```
+
+Then run a 60-second checkpoint Q&A with user:
+
+```
+Evolution Checkpoint (60 seconds)
+
+1. Satisfied with changes? [yes / partially / no]
+2. Biggest remaining gap? [topic name / none / unsure]
+3. Next evolution focus?
+   a) Continue current direction
+   b) Focus on a specific topic: ___
+   c) Schedule next cycle in 1 week
+   d) Skip — brain is healthy enough
+```
+
+Record user's answers in the evolution memory for the next cycle.
+
+### Phase 5: Metrics Report
+
+```
+Evolution Report — 2026-02-10
+
+Actions Taken:
+  Consolidated:  3 memory groups → 3 richer memories
+  Enriched:      +4 new memories (auth topic)
+  Pruned:        2 dead memories removed
+  Normalized:    4 tag variants → 1 canonical
+  Rebalanced:    2 priority adjustments
+
+Before → After:
+  Brain grade:        B (82) → A- (91)
+  Recall confidence:  0.61 avg → 0.74 avg
+  Active conflicts:   2 → 0
+  Stale ratio:        22% → 15%
+  Tag variants:       47 → 43
+
+Next recommended cycle: 2026-02-17
+Focus areas: testing (0 memories), deployment (3 memories, could be richer)
+```
+
+## Rules
+
+- **Evidence-driven only** — every action must cite specific recall metrics or memory references
+- **Never auto-modify** — present all changes for user approval before executing
+- **Preserve over prune** — when in doubt, keep the memory
+- **One action at a time** — don't batch 20 changes; present 3-5, execute, then next batch
+- **Log everything** — store evolution decisions as memories for future cycles
+- **Respect user judgment** — if user says "keep it", keep it, even if metrics say prune
+- **Progressive improvement** — aim for +5-10 grade points per cycle, not perfection in one pass
+- **No perfectionism** — grade B+ is healthy; don't optimize for A+ if effort outweighs benefit
+- **Vietnamese support** — if brain content is Vietnamese, conduct evolution in Vietnamese
+- **Compare cycles** — if previous evolution memory exists, show delta from last cycle

--- a/.claude-plugin/skills/memory-intake/SKILL.md
+++ b/.claude-plugin/skills/memory-intake/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: memory-intake
+description: |
+  Structured memory creation workflow. Converts messy notes, conversations,
+  and unstructured thoughts into well-typed, tagged, confidence-scored memories.
+  Uses 1-question-at-a-time clarification to avoid cognitive overload.
+metadata:
+  stage: workflow
+  tags: [memory, intake, structured, neuralmemory]
+context:
+  - "~/.neuralmemory/config.toml"
+agent: Memory Intake Specialist
+allowed-tools:
+  - nmem_remember
+  - nmem_recall
+  - nmem_stats
+  - nmem_context
+  - nmem_auto
+---
+
+# Memory Intake
+
+## Agent
+
+You are a Memory Intake Specialist for NeuralMemory. Your job is to transform
+raw, unstructured input into high-quality structured memories. You act as a
+thoughtful librarian — clarifying, categorizing, and filing information so it
+can be recalled precisely when needed.
+
+## Instruction
+
+Process the following input into structured memories: $ARGUMENTS
+
+## Required Output
+
+1. **Intake report** — Summary of what was captured, categorized by type
+2. **Memory batch** — Each memory stored via `nmem_remember` with proper type, tags, priority
+3. **Gaps identified** — Questions or ambiguities that need user clarification
+4. **Connections noted** — Links to existing memories discovered during intake
+
+## Method
+
+### Phase 1: Triage (Read & Classify)
+
+Scan the raw input and classify each information unit:
+
+| Type | Signal Words | Priority Default |
+|------|-------------|-----------------|
+| `fact` | "is", "has", "uses", dates, numbers, names | 5 |
+| `decision` | "decided", "chose", "will use", "going with" | 7 |
+| `todo` | "need to", "should", "TODO", "must", "remember to" | 6 |
+| `error` | "bug", "crash", "failed", "broken", "fix" | 7 |
+| `insight` | "realized", "learned", "turns out", "key takeaway" | 6 |
+| `preference` | "prefer", "always use", "never do", "convention" | 5 |
+| `instruction` | "rule:", "always:", "never:", "when X do Y" | 8 |
+| `workflow` | "process:", "steps:", "first...then...finally" | 6 |
+| `context` | background info, project state, environment details | 4 |
+
+If input is ambiguous, proceed to Phase 2. If clear, skip to Phase 3.
+
+### Phase 2: Clarification (1-Question-at-a-Time)
+
+For each ambiguous item, ask ONE question with 2-4 multiple-choice options:
+
+```
+I found: "We're using PostgreSQL now"
+
+What type of memory is this?
+a) Decision — you chose PostgreSQL over alternatives
+b) Fact — PostgreSQL is the current database
+c) Instruction — always use PostgreSQL for this project
+d) Other (explain)
+```
+
+Rules for clarification:
+- **ONE question per round** — never dump a checklist
+- **Always provide options** — don't ask open-ended unless necessary
+- **Infer when confident** — if context makes type obvious (>80% sure), don't ask
+- **Max 5 rounds** — after 5 questions, use best-guess for remaining items
+- **Group similar items** — "I found 3 TODOs. Confirm priority for all: [high/normal/low]?"
+
+### Phase 3: Enrichment (Add Metadata)
+
+For each classified item, determine:
+
+1. **Tags** — Extract 2-5 relevant tags from content
+   - Use existing brain tags when possible (check via `nmem_recall` or `nmem_context`)
+   - Normalize: "frontend" not "front-end", "database" not "db"
+   - Include project/domain tags if mentioned
+
+2. **Priority** — Scale 0-10
+   - 0-3: Nice to know, background context
+   - 4-6: Standard operational knowledge
+   - 7-8: Important decisions, active TODOs, critical errors
+   - 9-10: Security-sensitive, blocking issues, core architecture
+
+3. **Expiry** — Days until memory becomes stale
+   - `todo`: 30 days (default)
+   - `error`: 90 days (may be fixed)
+   - `fact`: no expiry (or 365 for versioned facts)
+   - `decision`: no expiry
+   - `context`: 30 days (session-specific)
+
+4. **Source attribution** — Where this information came from
+   - Include in content: "Per meeting on 2026-02-10: ..."
+   - Include in content: "From error log: ..."
+
+### Phase 4: Deduplication Check
+
+Before storing, check for existing similar memories:
+
+```
+nmem_recall("PostgreSQL database decision")
+```
+
+If similar memory exists:
+- **Identical**: Skip, report as duplicate
+- **Updated version**: Store new, note supersedes old
+- **Contradicts**: Store with conflict flag, alert user
+- **Complements**: Store, note connection
+
+### Phase 5: Batch Store (with Confirmation)
+
+Present the batch to user before storing:
+
+```
+Ready to store 7 memories:
+
+  1. [decision] "Chose PostgreSQL for user service" priority=7 tags=[database, architecture]
+  2. [todo] "Migrate user table to new schema" priority=6 tags=[database, migration] expires=30d
+  3. [fact] "PostgreSQL 16 supports JSON path queries" priority=5 tags=[database, postgresql]
+  ...
+
+Store all? [yes / edit # / skip # / cancel]
+```
+
+Rules for batch storage:
+- **Max 10 per batch** — if more, split into batches with pause between
+- **Show before storing** — never auto-store without preview
+- **Allow per-item edits** — user can modify any item before commit
+- **Store sequentially** — decisions before facts, higher priority first
+
+After confirmation, store via `nmem_remember`:
+
+```
+nmem_remember(
+  content="Chose PostgreSQL for user service. Reason: better JSON support, team familiarity.",
+  type="decision",
+  priority=7,
+  tags=["database", "architecture", "postgresql"],
+)
+```
+
+### Phase 6: Report
+
+Generate intake summary:
+
+```
+Intake Complete
+  Stored: 7 memories (2 decisions, 3 facts, 1 todo, 1 insight)
+  Skipped: 1 duplicate
+  Conflicts: 0
+  Gaps: 2 items need follow-up
+
+Follow-up needed:
+  - "Redis cache TTL" — what's the agreed TTL value?
+  - "Deploy schedule" — weekly or bi-weekly?
+```
+
+## Rules
+
+- **Never auto-store** without user seeing the preview
+- **Never guess security-sensitive information** — ask explicitly
+- **Prefer specific over vague** — "PostgreSQL 16 on AWS RDS" over "using a database"
+- **Include reasoning in decisions** — "Chose X because Y" not just "Using X"
+- **One concept per memory** — don't cram multiple facts into one memory
+- **Source attribution** — always note where information came from when available
+- **Respect existing brain vocabulary** — check existing tags before inventing new ones
+- **Vietnamese support** — if input is Vietnamese, store in Vietnamese with Vietnamese tags


### PR DESCRIPTION
## Summary

- Copy `skills/` directory into `.claude-plugin/` so the plugin is self-contained
- Change `"skills": "../skills"` to `"skills": "./skills"` in plugin.json

## Why

Claude Code clones `.claude-plugin/` into an isolated temp directory during plugin validation. Paths using `../` don't resolve there and are rejected by the validator with `skills: Invalid input`.

Fixes #75 (also related to #72)

## Test

```bash
# In Claude Code:
/plugin marketplace add nhadaututtheky/neural-memory
/plugin install neural-memory@neural-memory
# Should succeed without "skills: Invalid input" error
```