### PR TITLE
perf: singleton cache for embedding provider — prevent model reload per tool call

### DIFF
--- a/src/neural_memory/engine/semantic_discovery.py
+++ b/src/neural_memory/engine/semantic_discovery.py
@@ -115,8 +115,17 @@ def _auto_detect_provider() -> tuple[str, str]:
     )
 
 
+# ── Singleton cache for embedding providers ──────────────────
+# Prevents re-loading the model on every ReflexPipeline instantiation.
+# Keyed by (provider_name, model_name) so different configs get separate instances.
+_provider_cache: dict[tuple[str, str], Any] = {}
+
+
 def _create_provider(config: BrainConfig, task_type: str = "RETRIEVAL_QUERY") -> Any:
-    """Create an embedding provider from BrainConfig.
+    """Create (or return cached) embedding provider from BrainConfig.
+
+    Uses a module-level singleton cache keyed by (provider, model) to avoid
+    re-loading heavy models (e.g. SentenceTransformer) on every tool call.
 
     Args:
         config: Brain configuration with embedding_provider and embedding_model.
@@ -132,26 +141,34 @@ def _create_provider(config: BrainConfig, task_type: str = "RETRIEVAL_QUERY") ->
         provider_name, model_name = _auto_detect_provider()
         logger.info("Auto-detected embedding provider: %s (model: %s)", provider_name, model_name)
 
+    # Return cached instance if available
+    cache_key = (provider_name, model_name)
+    if cache_key in _provider_cache:
+        return _provider_cache[cache_key]
+
     if provider_name == "sentence_transformer":
         from neural_memory.engine.embedding.sentence_transformer import (
             SentenceTransformerEmbedding,
         )
 
-        return SentenceTransformerEmbedding(model_name=model_name)
+        provider = SentenceTransformerEmbedding(model_name=model_name)
     elif provider_name == "openai":
         from neural_memory.engine.embedding.openai_embedding import OpenAIEmbedding
 
-        return OpenAIEmbedding(model=model_name)
+        provider = OpenAIEmbedding(model=model_name)
     elif provider_name == "gemini":
         from neural_memory.engine.embedding.gemini_embedding import GeminiEmbedding
 
-        return GeminiEmbedding(model=model_name, task_type=task_type)
+        provider = GeminiEmbedding(model=model_name, task_type=task_type)
     elif provider_name == "ollama":
         from neural_memory.engine.embedding.ollama_embedding import OllamaEmbedding
 
-        return OllamaEmbedding(model=model_name)
+        provider = OllamaEmbedding(model=model_name)
     else:
         raise ValueError(f"Unknown embedding provider: {provider_name}")
+
+    _provider_cache[cache_key] = provider
+    return provider
 
 
 async def discover_semantic_synapses(


### PR DESCRIPTION
## Summary

Adds a module-level singleton cache to `_create_provider()` in `engine/semantic_discovery.py`.

## Problem

`ReflexPipeline.__init__()` calls `_create_provider()` which creates a **new** embedding provider instance every time. In MCP server context, every tool call creates a new `ReflexPipeline`, causing the SentenceTransformer model to reload on every recall/capture.

With OpenClaw's autoContext + autoCapture, this resulted in **48 model loads in 20 minutes** of conversation.

## Fix

Cache provider instances by `(provider_name, model_name)` tuple. Same provider+model combo returns the cached instance.

```python
_provider_cache: dict[tuple[str, str], Any] = {}

def _create_provider(config, task_type="RETRIEVAL_QUERY"):
    # ... resolve provider_name, model_name ...
    cache_key = (provider_name, model_name)
    if cache_key in _provider_cache:
        return _provider_cache[cache_key]
    # ... create provider ...
    _provider_cache[cache_key] = provider
    return provider
```

## Result

- **Before:** 48 model loads in 20 min (every turn)
- **After:** 1 model load (first use), cached for MCP process lifetime

Fixes #100