### PR TITLE
chore: change Reusing MCP client log from info to debug

### DIFF
--- a/integrations/neuralmemory/src/index.ts
+++ b/integrations/neuralmemory/src/index.ts
@@ -177,7 +177,7 @@ function getOrCreateMcpClient(
 
   const existing = mcpClients.get(key);
   if (existing) {
-    logger.info(`Reusing existing MCP client for brain "${cfg.brain}"`);
+    logger.debug(`Reusing existing MCP client for brain "${cfg.brain}"`);
     return existing;
   }
 


### PR DESCRIPTION
## Summary

Changes `logger.info` to `logger.debug` for the "Reusing existing MCP client" message in `getOrCreateMcpClient()`.

This log fires on every hook invocation when a cached client exists, flooding logs at info level. Debug level is more appropriate for this routine cache-hit message.

Fixes nhadaututtheky/neural-memory#103