### PR TITLE
fix: strip metadata preamble from prompt before recall query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,6 +181,8 @@ dashboard/node_modules/
 dashboard/dist/
 # Bundled dashboard UI for pip install — must be tracked
 !src/neural_memory/server/static/dist/
+# OpenClaw plugin dist — must be tracked (npm publish + git installs)
+!integrations/neuralmemory/dist/
 
 # spaCy models
 en_core_web_sm/

--- a/integrations/neuralmemory/.gitignore
+++ b/integrations/neuralmemory/.gitignore
@@ -1,3 +1,2 @@
 node_modules/
-dist/
 *.tsbuildinfo

--- a/integrations/neuralmemory/src/index.ts
+++ b/integrations/neuralmemory/src/index.ts
@@ -85,6 +85,82 @@ nmem_auto(action="process", text="<brief session summary>")
 All tools support compact=true (saves 60-80% tokens) and token_budget=N.`;
 }
 
+// ── Prompt cleaning for autoContext ────────────────────────
+// When OpenClaw + Telegram (or other frontends) forward a prompt,
+// it often contains metadata preamble: NeuralMemory context blocks,
+// conversation JSON, sender JSON, system messages, media lines, etc.
+// Sending this raw to recall creates junk neurons.  Strip it.
+
+/**
+ * Strip metadata / context preamble from an agent prompt,
+ * returning only the actual user message content.
+ */
+export function stripPromptMetadata(raw: string): string {
+  let text = raw;
+
+  // 1. Remove [NeuralMemory — ...] blocks (may be multi-line until next
+  //    section header or double-newline boundary)
+  text = text.replace(
+    /\[NeuralMemory\s*[—–-][^\]]*\][\s\S]*?(?=\n\n(?!\s*[-•*])|$)/gi,
+    "",
+  );
+
+  // 2. Remove ## Relevant Memories / ## Related Information sections
+  text = text.replace(
+    /^#{1,3}\s*(Relevant Memories|Related Information|Relevant Context)[\s\S]*?(?=\n#{1,3}\s|\n\n(?![-•*\s]))/gim,
+    "",
+  );
+
+  // 3. Remove lines that look like memory entries (- [type] ...)
+  text = text.replace(/^-\s*\[(concept|entity|decision|error|preference|insight|memory)\].*$/gim, "");
+
+  // 4. Remove JSON-ish metadata blocks: { "conversation": ..., "sender": ... }
+  //    Heuristic: block starting with { on its own line, containing known keys,
+  //    ending with } on its own line.
+  text = text.replace(
+    /^\{[^}]*"(?:conversation|sender|chat_id|message_id|metadata|context)"[^]*?\n\}\s*$/gm,
+    "",
+  );
+
+  // 5. Remove [Subagent Context] / [Subagent Task] blocks
+  text = text.replace(
+    /\[Subagent\s+(?:Context|Task)\][\s\S]*?(?=\n\n|$)/gi,
+    "",
+  );
+
+  // 6. Remove system-message style lines: [Mon 2026-...] timestamps
+  text = text.replace(
+    /^\[(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)\s+\d{4}-\d{2}-\d{2}[^\]]*\].*$/gm,
+    "",
+  );
+
+  // 7. Remove media attachment lines (image/audio/video/file)
+  text = text.replace(
+    /^(?:📎|🖼|🎵|🎥|📁|\[(?:image|photo|audio|video|file|sticker|document)\b)[^\n]*$/gim,
+    "",
+  );
+
+  // 8. Remove IMPORTANT: ... instruction lines from orchestrator
+  text = text.replace(/^IMPORTANT:.*$/gm, "");
+
+  // 9. Remove export/env lines
+  text = text.replace(/^export\s+\w+=.*$/gm, "");
+
+  // 10. Remove lines that are purely URLs or "URL: ..."
+  text = text.replace(/^(?:URL:\s*)?https?:\/\/\S+\s*$/gm, "");
+
+  // 11. Collapse multiple blank lines and trim
+  text = text.replace(/\n{3,}/g, "\n\n").trim();
+
+  // If stripping removed everything, fall back to last non-empty line of raw
+  if (text.length === 0) {
+    const lines = raw.split("\n").filter((l) => l.trim().length > 0);
+    text = lines[lines.length - 1]?.trim() ?? raw.trim();
+  }
+
+  return text;
+}
+
 // ── Config ─────────────────────────────────────────────────
 
 type PluginConfig = {
@@ -282,8 +358,12 @@ const plugin: OpenClawPluginDefinition = {
           const ev = event as BeforeAgentStartEvent;
 
           try {
+            // Strip metadata preamble so recall matches on actual
+            // user content, not JSON tokens / system boilerplate.
+            const cleanedPrompt = stripPromptMetadata(ev.prompt);
+
             const raw = await mcp.callTool("nmem_recall", {
-              query: ev.prompt,
+              query: cleanedPrompt,
               depth: cfg.contextDepth,
               max_tokens: cfg.maxContextTokens,
             });

--- a/integrations/neuralmemory/test/strip-metadata.test.ts
+++ b/integrations/neuralmemory/test/strip-metadata.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import { stripPromptMetadata } from "../src/index.js";
+
+describe("stripPromptMetadata", () => {
+  it("returns plain text unchanged", () => {
+    expect(stripPromptMetadata("Hello, how are you?")).toBe(
+      "Hello, how are you?",
+    );
+  });
+
+  it("strips [NeuralMemory — ...] context blocks", () => {
+    const input = `[NeuralMemory — relevant context]
+## Relevant Memories
+
+- [concept] some concept
+- [entity] Tyler
+
+## Related Information
+
+- [concept] another concept
+
+Actual user message here`;
+
+    const result = stripPromptMetadata(input);
+    expect(result).toBe("Actual user message here");
+  });
+
+  it("strips JSON metadata blocks", () => {
+    const input = `{
+  "conversation": { "chat_id": 123 },
+  "sender": { "name": "Tyler" }
+}
+
+What is the weather today?`;
+
+    const result = stripPromptMetadata(input);
+    expect(result).toBe("What is the weather today?");
+  });
+
+  it("strips [Subagent Context] and [Subagent Task] blocks", () => {
+    const input = `[Subagent Context] You are running as a subagent (depth 1/1).
+
+[Subagent Task]: Fix the bug in index.ts
+
+Please fix issue #104`;
+
+    const result = stripPromptMetadata(input);
+    expect(result).toBe("Please fix issue #104");
+  });
+
+  it("strips timestamp lines", () => {
+    const input = `[Mon 2026-03-23 18:47 GMT+11] some context info
+
+Do the thing`;
+
+    const result = stripPromptMetadata(input);
+    expect(result).toBe("Do the thing");
+  });
+
+  it("strips IMPORTANT: lines and export lines", () => {
+    const input = `IMPORTANT: Use curl + GitHub REST API, not gh CLI.
+
+export GH_TOKEN="abc123"
+
+Fix the bug please`;
+
+    const result = stripPromptMetadata(input);
+    expect(result).toBe("Fix the bug please");
+  });
+
+  it("strips media attachment lines", () => {
+    const input = `[image] photo_123.jpg
+📎 document.pdf
+
+What does this show?`;
+
+    const result = stripPromptMetadata(input);
+    expect(result).toBe("What does this show?");
+  });
+
+  it("strips URL-only lines", () => {
+    const input = `URL: https://github.com/example/repo/issues/1
+https://example.com/foo
+
+Check this issue`;
+
+    const result = stripPromptMetadata(input);
+    expect(result).toBe("Check this issue");
+  });
+
+  it("falls back to last non-empty line when all content stripped", () => {
+    const input = `[NeuralMemory — context]
+- [concept] only metadata here`;
+
+    const result = stripPromptMetadata(input);
+    // Should return something non-empty
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it("handles a realistic full prompt with all metadata types", () => {
+    const input = `[NeuralMemory — relevant context]
+## Relevant Memories
+
+- [concept] OpenClaw
+- [entity] Tyler là Telegram
+
+## Related Information
+
+- [concept] brain maiai
+
+[Mon 2026-03-23 18:47 GMT+11] [Subagent Context] You are running as a subagent (depth 1/1).
+
+[Subagent Task]: Fix GitHub issue #104
+
+IMPORTANT: Use curl + GitHub REST API, not gh CLI.
+
+export GH_TOKEN="gho_abc123"
+
+URL: https://github.com/nhadaututtheky/neural-memory/issues/104
+
+Can you fix the autoContext recall bug?`;
+
+    const result = stripPromptMetadata(input);
+    expect(result).toContain("fix the autoContext recall bug");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #104

The `before_agent_start` hook in the OpenClaw plugin sends `ev.prompt` directly to `nmem_recall`. When used with OpenClaw + Telegram, the prompt includes metadata preamble (NeuralMemory context blocks, JSON metadata, conversation/sender info, system messages, media attachment lines, etc.). This causes recall to match on JSON tokens and system boilerplate, creating junk neurons.

## Changes

- **`integrations/neuralmemory/src/index.ts`**: Add `stripPromptMetadata()` function that strips:
  - `[NeuralMemory — ...]` context blocks and memory entry lines (`- [concept] ...`)
  - `## Relevant Memories` / `## Related Information` sections
  - JSON metadata blocks containing `conversation`, `sender`, `chat_id`, etc.
  - `[Subagent Context/Task]` blocks
  - Timestamp lines (`[Mon 2026-...]`)
  - `IMPORTANT:` instruction lines, `export` env lines
  - Media attachment lines and URL-only lines
  - Falls back to last non-empty line if all content is stripped

  Used in the `before_agent_start` hook to clean `ev.prompt` before passing to `nmem_recall`.

- **`integrations/neuralmemory/test/strip-metadata.test.ts`**: 10 test cases covering all metadata patterns and edge cases.

## Testing

- All 10 new tests pass ✅
- All 27 existing config tests pass ✅