### PR TITLE
fix: skip missing synapses during decay

### DIFF
--- a/src/neural_memory/engine/lifecycle.py
+++ b/src/neural_memory/engine/lifecycle.py
@@ -4,6 +4,9 @@ Implements the Ebbinghaus forgetting curve for natural memory decay
 and reinforcement for frequently accessed memories.
 """
 
+# Background maintenance should degrade gracefully if a synapse disappears
+# between enumeration and update.
+
 from __future__ import annotations
 
 import logging
@@ -238,13 +241,29 @@ class DecayManager:
                 if new_weight < self.prune_threshold:
                     report.synapses_pruned += 1
                     if not dry_run:
-                        # Zero out weight for pruned synapses
+                        # A synapse can be deleted after enumeration but before update.
                         pruned_synapse = synapse.decay(0.0)
-                        await storage.update_synapse(pruned_synapse)
+                        try:
+                            await storage.update_synapse(pruned_synapse)
+                        except ValueError as exc:
+                            if f"Synapse {synapse.id} does not exist" not in str(exc):
+                                raise
+                            logger.warning(
+                                "Skipping decay update for missing synapse %s",
+                                synapse.id,
+                            )
 
                 elif not dry_run:
                     decayed_synapse = synapse.decay(decay_factor)
-                    await storage.update_synapse(decayed_synapse)
+                    try:
+                        await storage.update_synapse(decayed_synapse)
+                    except ValueError as exc:
+                        if f"Synapse {synapse.id} does not exist" not in str(exc):
+                            raise
+                        logger.warning(
+                            "Skipping decay update for missing synapse %s",
+                            synapse.id,
+                        )
 
         report.duration_ms = (time.perf_counter() - start_time) * 1000
         return report

--- a/tests/unit/test_pinned_lifecycle.py
+++ b/tests/unit/test_pinned_lifecycle.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import replace as dc_replace
 from datetime import timedelta
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -147,6 +148,42 @@ class TestPinnedDecayBypass:
         assert updated_state.activation_level < 1.0
 
         await storage.close()
+
+
+class TestDecayMissingSynapse:
+    """Test decay tolerates synapses deleted mid-run."""
+
+    @pytest.fixture()
+    def decay_manager(self):
+        from neural_memory.engine.lifecycle import DecayManager
+
+        return DecayManager(decay_rate=0.1, prune_threshold=0.01, min_age_days=0)
+
+    async def test_missing_synapse_is_skipped(self, decay_manager):
+        old_time = utcnow() - timedelta(days=30)
+        synapse = Synapse.create(
+            source_id="n1",
+            target_id="n2",
+            type=SynapseType.RELATED_TO,
+            weight=0.5,
+            synapse_id="syn-missing",
+        )
+        synapse = dc_replace(synapse, last_activated=old_time)
+
+        storage = AsyncMock()
+        storage.get_pinned_neuron_ids.return_value = set()
+        storage.get_fibers.return_value = []
+        storage.get_all_neuron_states.return_value = []
+        storage.get_all_synapses.return_value = [synapse]
+        storage.update_synapse.side_effect = ValueError(
+            f"Synapse {synapse.id} does not exist"
+        )
+
+        report = await decay_manager.apply_decay(storage)
+
+        assert report.synapses_processed == 1
+        assert report.synapses_decayed == 1
+        storage.update_synapse.assert_awaited_once()
 
 
 class TestPinnedCompressionBypass:


### PR DESCRIPTION
## What
- make `DecayManager.apply_decay()` tolerate synapses that disappear between enumeration and update
- log and skip `ValueError: Synapse ... does not exist` instead of failing the whole decay run
- add a regression test for the missing-synapse race case

## Why
When `nmem.service` runs background decay, a missing synapse can currently abort the maintenance task and break service-online behavior even though the rest of the brain remains usable.

## Validation
- `python -m pytest -q tests/unit/test_pinned_lifecycle.py`
