### PR TITLE
fix(cli): close coroutine on sandbox fail-fast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — Coroutine warning on sandbox fail-fast (#153)
+
+CLI commands that fail fast in restricted sandboxes no longer emit
+`RuntimeWarning: coroutine was never awaited`. The unawaited command
+coroutine is now explicitly closed before re-raising the sandbox exit.
+
 ## [4.53.4] — 2026-04-30
 
 ### Fixed — Sandbox Hang at Every Storage Entry Point (#151)

--- a/src/neural_memory/cli/_helpers.py
+++ b/src/neural_memory/cli/_helpers.py
@@ -39,7 +39,11 @@ def run_async(coro: Coroutine[Any, Any, T]) -> T:
     """
     from neural_memory.utils.sandbox import ensure_aiosqlite_or_exit_cli
 
-    ensure_aiosqlite_or_exit_cli()
+    try:
+        ensure_aiosqlite_or_exit_cli()
+    except BaseException:
+        coro.close()
+        raise
 
     async def _with_cleanup() -> T:
         try:

--- a/tests/unit/test_sandbox_probe.py
+++ b/tests/unit/test_sandbox_probe.py
@@ -8,7 +8,9 @@ not hang silently.
 from __future__ import annotations
 
 import asyncio
+import gc
 import os
+import warnings
 from typing import Any
 from unittest.mock import patch
 
@@ -173,6 +175,29 @@ class TestCliRunAsyncIntegration:
 
         with pytest.raises(typer.Exit):
             run_async(_noop())
+
+    def test_run_async_closes_unawaited_coro_when_probe_fails(self) -> None:
+        import typer
+
+        from neural_memory.cli._helpers import run_async
+
+        sandbox._cached_result = sandbox.ProbeResult(
+            ok=False, detail="hung", error_class="TimeoutError"
+        )
+
+        async def _context() -> int:
+            return 1
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", RuntimeWarning)
+            with pytest.raises(typer.Exit):
+                run_async(_context())
+            gc.collect()
+
+        warning_messages = [str(w.message) for w in caught]
+        assert not any(
+            "coroutine" in msg and "was never awaited" in msg for msg in warning_messages
+        )
 
     def test_run_async_executes_when_probe_ok(self) -> None:
         from neural_memory.cli._helpers import run_async


### PR DESCRIPTION
## Summary

Fixes the residual CLI warning reported after the sandbox fail-fast change. When the aiosqlite sandbox probe exits before a command coroutine is awaited, the coroutine is now explicitly closed before the CLI re-raises the fail-fast exit.

## Why

Storage-backed commands such as `nmem context` can fail fast in restricted sandboxes. Without closing the pending command coroutine, Python may emit:

`RuntimeWarning: coroutine 'context.<locals>._context' was never awaited`

That warning adds noise to the actual sandbox diagnostic.

## Changes

- Close unawaited command coroutines when the sandbox preflight exits early.
- Add a regression test that forces GC and asserts the warning is not emitted.

## Verification

- `ruff check src/neural_memory/cli/_helpers.py tests/unit/test_sandbox_probe.py`
- `pytest tests/unit/test_sandbox_probe.py -q`
- Manual sandbox repro: `timeout 8s .venv/bin/nmem context` exits with the sandbox error and no coroutine warning.
