### PR TITLE
feat(doctor): add contributor dev diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Contributor dev diagnostics (#154)
+
+`nmem doctor --dev` now reports source checkout detection, editable install
+status, dev dependencies, and checkout/package version parity for
+contributors working from a source checkout.
+
 ### Fixed — Coroutine warning on sandbox fail-fast (#153)
 
 CLI commands that fail fast in restricted sandboxes no longer emit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,7 @@ Please be respectful and constructive in all interactions. We're building someth
 5. **Verify setup**
 
    ```bash
+   nmem doctor --dev
    pytest tests/ -v
    mypy src/
    ruff check src/ tests/

--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ Zero LLM calls, zero API cost. [Full benchmarks →](docs/benchmarks.md)
 ```bash
 git clone https://github.com/nhadaututtheky/neural-memory
 cd neural-memory && pip install -e ".[dev]"
+nmem doctor --dev        # Verify contributor setup
 pytest tests/ -v          # 7100+ tests
 ruff check src/ tests/    # Lint
 ```

--- a/docs/getting-started/cli-reference.md
+++ b/docs/getting-started/cli-reference.md
@@ -400,6 +400,7 @@ nmem doctor [OPTIONS]
 |--------|------|----------|---------|-------------|
 | `--json / -j` | boolean | No | `False` | Output as JSON |
 | `--fix` | boolean | No | `False` | Auto-fix available issues |
+| `--dev` | boolean | No | `False` | Include source checkout and contributor tooling checks |
 
 ### `nmem dashboard`
 

--- a/src/neural_memory/cli/commands/tools.py
+++ b/src/neural_memory/cli/commands/tools.py
@@ -915,6 +915,10 @@ def flush(
 def doctor(
     json_output: Annotated[bool, typer.Option("--json", "-j", help="Output as JSON")] = False,
     fix: Annotated[bool, typer.Option("--fix", help="Auto-fix available issues")] = False,
+    dev: Annotated[
+        bool,
+        typer.Option("--dev", help="Include source checkout and contributor tooling checks"),
+    ] = False,
 ) -> None:
     """Run system health diagnostics.
 
@@ -922,17 +926,19 @@ def doctor(
     schema version, MCP config, hooks, dedup, surface, and CLI tools.
 
     Use --fix to automatically remediate fixable issues.
+    Use --dev to check contributor setup in a source checkout.
 
     Examples:
         nmem doctor          # Run all checks
         nmem doctor --fix    # Auto-fix what's possible
+        nmem doctor --dev    # Include contributor setup checks
         nmem doctor --json   # Machine-readable output
     """
     import json as json_mod
 
     from neural_memory.cli.doctor import run_doctor
 
-    result = run_doctor(json_output=json_output, fix=fix)
+    result = run_doctor(json_output=json_output, fix=fix, dev=dev)
 
     if json_output:
         typer.echo(json_mod.dumps(result, indent=2, default=str))

--- a/src/neural_memory/cli/doctor.py
+++ b/src/neural_memory/cli/doctor.py
@@ -9,6 +9,7 @@ with actionable fix suggestions. Supports --fix for auto-remediation.
 from __future__ import annotations
 
 import importlib
+import importlib.metadata
 import json
 import shutil
 import sys
@@ -27,6 +28,7 @@ SKIP = "skip"
 TIER_CORE = "core"  # required for basic operation
 TIER_RECOMMENDED = "recommended"  # recommended for full power (embeddings, MCP, hooks)
 TIER_OPTIONAL = "optional"  # nice-to-have (surface snapshot, pro plugin, etc.)
+TIER_DEV = "dev"  # contributor/source checkout diagnostics
 
 # Check name → tier mapping. Unassigned defaults to RECOMMENDED.
 _CHECK_TIERS: dict[str, str] = {
@@ -45,17 +47,27 @@ _CHECK_TIERS: dict[str, str] = {
     "Config freshness": TIER_OPTIONAL,
     "Pro features": TIER_OPTIONAL,
     "Orphan fibers": TIER_OPTIONAL,
+    "Source checkout": TIER_DEV,
+    "Editable install": TIER_DEV,
+    "Dev dependencies": TIER_DEV,
+    "Checkout version": TIER_DEV,
 }
 
 QUICKSTART_URL = "https://nhadaututtheky.github.io/neural-memory/guides/quickstart/"
 
 
-def run_doctor(*, json_output: bool = False, fix: bool = False) -> dict[str, Any]:
+def run_doctor(
+    *,
+    json_output: bool = False,
+    fix: bool = False,
+    dev: bool = False,
+) -> dict[str, Any]:
     """Run all diagnostic checks and return results.
 
     Args:
         json_output: Return machine-readable output.
         fix: Auto-fix what's possible (enable config flags, install hooks).
+        dev: Include source checkout diagnostics for contributors.
     """
     checks: list[dict[str, Any]] = []
 
@@ -74,6 +86,8 @@ def run_doctor(*, json_output: bool = False, fix: bool = False) -> dict[str, Any
     checks.append(_check_cli_tools())
     checks.append(_check_pro_plugin())
     checks.append(_check_orphan_fibers())
+    if dev:
+        checks.extend(_check_dev_environment())
 
     # Auto-fix pass
     if fix:
@@ -100,6 +114,162 @@ def run_doctor(*, json_output: bool = False, fix: bool = False) -> dict[str, Any
         _render_results(result)
 
     return result
+
+
+def _source_checkout_root() -> Path | None:
+    """Return the repository root when running from a source checkout."""
+    root = Path(__file__).resolve().parents[3]
+    if (root / "pyproject.toml").exists() and (root / "src" / "neural_memory").exists():
+        return root
+    return None
+
+
+def _read_checkout_version(root: Path) -> str | None:
+    """Read ``project.version`` from a source checkout."""
+    try:
+        import tomllib
+
+        data = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
+        version = data.get("project", {}).get("version")
+        return str(version) if version else None
+    except Exception:
+        return None
+
+
+def _check_dev_environment() -> list[dict[str, Any]]:
+    """Contributor-focused diagnostics for source checkouts."""
+    root = _source_checkout_root()
+    return [
+        _check_dev_source_checkout(root),
+        _check_dev_editable_install(root),
+        _check_dev_dependencies(),
+        _check_dev_checkout_version(root),
+    ]
+
+
+def _check_dev_source_checkout(root: Path | None = None) -> dict[str, Any]:
+    """Check whether doctor is running from a repository checkout."""
+    root = _source_checkout_root() if root is None else root
+    if root is None:
+        return {
+            "name": "Source checkout",
+            "status": SKIP,
+            "detail": "not running from a source checkout",
+        }
+    return {
+        "name": "Source checkout",
+        "status": OK,
+        "detail": str(root),
+    }
+
+
+def _check_dev_editable_install(root: Path | None = None) -> dict[str, Any]:
+    """Check whether imports resolve to the current checkout."""
+    root = _source_checkout_root() if root is None else root
+    if root is None:
+        return {
+            "name": "Editable install",
+            "status": SKIP,
+            "detail": "source checkout not detected",
+        }
+
+    try:
+        import neural_memory
+
+        package_path = Path(neural_memory.__file__).resolve()
+        package_path.relative_to(root / "src")
+        return {
+            "name": "Editable install",
+            "status": OK,
+            "detail": "importing from checkout src/",
+        }
+    except ValueError:
+        return {
+            "name": "Editable install",
+            "status": WARN,
+            "detail": "importing installed package, not checkout src/",
+            "fix": 'Run: pip install -e ".[dev]"',
+        }
+    except Exception:
+        return {
+            "name": "Editable install",
+            "status": WARN,
+            "detail": "could not inspect import path",
+            "fix": 'Run: pip install -e ".[dev]"',
+        }
+
+
+def _check_dev_dependencies() -> dict[str, Any]:
+    """Check contributor tooling dependencies."""
+    required = {
+        "pytest": "pytest",
+        "pytest-asyncio": "pytest_asyncio",
+        "ruff": "ruff",
+        "mypy": "mypy",
+    }
+    missing = []
+    for package_name, module_name in required.items():
+        try:
+            importlib.import_module(module_name)
+        except ImportError:
+            missing.append(package_name)
+
+    if missing:
+        return {
+            "name": "Dev dependencies",
+            "status": FAIL,
+            "detail": f"missing: {', '.join(missing)}",
+            "fix": 'Run: pip install -e ".[dev]"',
+        }
+
+    return {
+        "name": "Dev dependencies",
+        "status": OK,
+        "detail": "pytest, pytest-asyncio, ruff, mypy available",
+    }
+
+
+def _check_dev_checkout_version(root: Path | None = None) -> dict[str, Any]:
+    """Compare checkout version with the installed package metadata."""
+    root = _source_checkout_root() if root is None else root
+    if root is None:
+        return {
+            "name": "Checkout version",
+            "status": SKIP,
+            "detail": "source checkout not detected",
+        }
+
+    checkout_version = _read_checkout_version(root)
+    if checkout_version is None:
+        return {
+            "name": "Checkout version",
+            "status": WARN,
+            "detail": "could not read pyproject.toml version",
+        }
+
+    try:
+        installed_version = importlib.metadata.version("neural-memory")
+    except importlib.metadata.PackageNotFoundError:
+        return {
+            "name": "Checkout version",
+            "status": WARN,
+            "detail": f"checkout {checkout_version}; package not installed",
+            "fix": 'Run: pip install -e ".[dev]"',
+        }
+
+    if installed_version == checkout_version:
+        return {
+            "name": "Checkout version",
+            "status": OK,
+            "detail": f"checkout {checkout_version}; installed {installed_version}",
+        }
+
+    return {
+        "name": "Checkout version",
+        "status": WARN,
+        "detail": f"checkout {checkout_version}; installed {installed_version}",
+        "fix": 'Run: pip install -e ".[dev]"',
+    }
 
 
 def _check_python_version() -> dict[str, Any]:
@@ -899,9 +1069,10 @@ def _render_results(result: dict[str, Any]) -> None:
         TIER_CORE: ("CORE", "required for basic operation"),
         TIER_RECOMMENDED: ("RECOMMENDED", "full-power setup"),
         TIER_OPTIONAL: ("OPTIONAL", "nice-to-have, not needed for basic use"),
+        TIER_DEV: ("DEV", "source checkout and contributor tooling"),
     }
 
-    for tier in (TIER_CORE, TIER_RECOMMENDED, TIER_OPTIONAL):
+    for tier in (TIER_CORE, TIER_RECOMMENDED, TIER_OPTIONAL, TIER_DEV):
         tier_checks = [c for c in result["checks"] if c.get("tier") == tier]
         if not tier_checks:
             continue

--- a/tests/unit/test_dx_wizard.py
+++ b/tests/unit/test_dx_wizard.py
@@ -140,6 +140,39 @@ class TestDoctor:
             result = _check_cli_tools()
             assert result["status"] == "fail"
 
+    def test_check_dev_dependencies_missing(self) -> None:
+        from neural_memory.cli.doctor import _check_dev_dependencies
+
+        with patch("neural_memory.cli.doctor.importlib.import_module", side_effect=ImportError):
+            result = _check_dev_dependencies()
+            assert result["status"] == "fail"
+            assert 'pip install -e ".[dev]"' in result["fix"]
+
+    def test_check_dev_checkout_version_matches(self, tmp_path: Path) -> None:
+        from neural_memory.cli.doctor import _check_dev_checkout_version
+
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text('[project]\nversion = "1.2.3"\n', encoding="utf-8")
+
+        with patch("neural_memory.cli.doctor.importlib.metadata.version", return_value="1.2.3"):
+            result = _check_dev_checkout_version(tmp_path)
+
+        assert result["status"] == "ok"
+        assert "checkout 1.2.3" in result["detail"]
+
+    def test_check_dev_checkout_version_mismatch(self, tmp_path: Path) -> None:
+        from neural_memory.cli.doctor import _check_dev_checkout_version
+
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text('[project]\nversion = "4.53.4"\n', encoding="utf-8")
+
+        with patch("neural_memory.cli.doctor.importlib.metadata.version", return_value="4.53.2"):
+            result = _check_dev_checkout_version(tmp_path)
+
+        assert result["status"] == "warn"
+        assert "checkout 4.53.4; installed 4.53.2" in result["detail"]
+        assert 'pip install -e ".[dev]"' in result["fix"]
+
     def test_run_doctor_returns_summary(self) -> None:
         from neural_memory.cli.doctor import run_doctor
 
@@ -196,6 +229,40 @@ class TestDoctor:
             result = run_doctor(json_output=True)
             assert result["failed"] == 1
             assert result["passed"] == 14
+
+    def test_run_doctor_dev_adds_dev_checks(self) -> None:
+        from neural_memory.cli.doctor import run_doctor
+
+        with (
+            patch("neural_memory.cli.doctor._check_python_version") as m1,
+            patch("neural_memory.cli.doctor._check_config") as m2,
+            patch("neural_memory.cli.doctor._check_brain") as m3,
+            patch("neural_memory.cli.doctor._check_dependencies") as m4,
+            patch("neural_memory.cli.doctor._check_embedding_provider") as m5,
+            patch("neural_memory.cli.doctor._check_schema_version") as m6,
+            patch("neural_memory.cli.doctor._check_mcp_config") as m7,
+            patch("neural_memory.cli.doctor._check_mcp_connection") as m7b,
+            patch("neural_memory.cli.doctor._check_cli_tools") as m8,
+            patch("neural_memory.cli.doctor._check_hooks") as m9,
+            patch("neural_memory.cli.doctor._check_dedup") as m10,
+            patch("neural_memory.cli.doctor._check_surface") as m11,
+            patch("neural_memory.cli.doctor._check_config_freshness") as m12,
+            patch("neural_memory.cli.doctor._check_pro_plugin") as m13,
+            patch("neural_memory.cli.doctor._check_orphan_fibers") as m14,
+            patch("neural_memory.cli.doctor._check_dev_environment") as m15,
+        ):
+            for m in [m1, m2, m3, m4, m5, m6, m7, m7b, m8, m9, m10, m11, m12, m13, m14]:
+                m.return_value = {"name": "test", "status": "ok", "detail": "ok"}
+            m15.return_value = [
+                {"name": "Source checkout", "status": "ok", "detail": "ok"},
+                {"name": "Dev dependencies", "status": "ok", "detail": "ok"},
+            ]
+
+            result = run_doctor(json_output=True, dev=True)
+
+        assert result["passed"] == 17
+        assert result["total"] == 17
+        assert any(c["tier"] == "dev" for c in result["checks"])
 
 
 # ──────────────────── Embedding Setup ────────────────────
@@ -384,6 +451,14 @@ class TestDoctorCommand:
         from neural_memory.cli.commands.tools import doctor
 
         assert callable(doctor)
+
+    def test_doctor_accepts_dev_option(self) -> None:
+        import inspect
+
+        from neural_memory.cli.commands.tools import doctor
+
+        sig = inspect.signature(doctor)
+        assert "dev" in sig.parameters
 
     def test_setup_function_exists(self) -> None:
         from neural_memory.cli.commands.tools import setup


### PR DESCRIPTION
## Summary

Adds `nmem doctor --dev` for contributors working from a source checkout.

## Why

Contributor setup problems are easy to miss: non-editable installs, missing dev dependencies, or a checkout version that differs from the installed package can make local test results misleading. A focused doctor mode gives contributors a quick check before filing or reviewing fixes.

## Changes

- Add a `--dev` option to `nmem doctor`.
- Report source checkout detection, editable install status, dev dependencies, and checkout/package version parity.
- Add tests for the new diagnostics and CLI signature.
- Document `nmem doctor --dev` in README and CONTRIBUTING.

## Verification

- `ruff check src/neural_memory/cli/doctor.py src/neural_memory/cli/commands/tools.py tests/unit/test_dx_wizard.py`
- `pytest tests/unit/test_dx_wizard.py -q`
- Manual run: `nmem doctor --dev`
- Manual run: `nmem doctor --dev --json`
