### PR TITLE
fix(cli): keep machine output free of advisory noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — Advisory hints stripped from machine output (#155)
+
+CLI update notices are now skipped for machine-oriented commands
+(`context`, `recall`, `stats`, `status`) and any invocation with `--json`.
+MCP `strip_hints` now strips advisory fields even in non-compact mode.
+Adds an Agent Memory Governance guide.
+
 ### Added — Contributor dev diagnostics (#154)
 
 `nmem doctor --dev` now reports source checkout detection, editable install

--- a/docs/guides/agent-memory-governance.md
+++ b/docs/guides/agent-memory-governance.md
@@ -1,0 +1,118 @@
+# Agent Memory Governance
+
+NeuralMemory is most useful when agents store durable context, not every passing detail. Use these guidelines to keep memory useful, auditable, and safe.
+
+## Store Durable Signals
+
+Good memories help a future agent make a better decision.
+
+Store:
+
+- Project decisions and the reason they were made
+- User preferences that should change future behavior
+- Repeated workflow constraints
+- Confirmed facts about the current project
+- Resolutions to errors that are likely to recur
+- Handoffs, open questions, and next actions
+
+Avoid storing:
+
+- Raw command output unless the exact output is needed later
+- Temporary status updates that will be stale in hours
+- Speculation without a clear uncertainty marker
+- Large copied documents when a source reference is enough
+- Secrets, tokens, credentials, private keys, or regulated personal data
+
+## Mark Confidence And Source
+
+When a memory may influence later work, include enough context to judge it.
+
+Prefer:
+
+```bash
+nmem remember "Decision: keep update notices out of JSON output because agents parse CLI stdout as structured context. Source: issue triage on 2026-04-30." --type decision
+```
+
+Over:
+
+```bash
+nmem remember "JSON output is fixed"
+```
+
+Useful details include:
+
+- Source: issue, PR, commit, file, meeting, or user instruction
+- Date: when the statement was observed or decided
+- Confidence: confirmed, inferred, tentative, or needs-review
+- Scope: project, branch, user, environment, or tool
+
+## Keep Machine Output Clean
+
+Agents often feed CLI and MCP output back into prompts. Human-facing banners, advisory hints, and package update notices can pollute summaries.
+
+For automation:
+
+```bash
+nmem context --json
+nmem status --json
+nmem stats --json
+nmem recall "deployment constraints" --json
+```
+
+For MCP clients, use compact responses when the client supports it:
+
+```json
+{
+  "query": "deployment constraints",
+  "compact": true
+}
+```
+
+By default, MCP response hint fields such as `maintenance_hint`, `update_hint`, and `onboarding` are controlled by:
+
+```toml
+[response]
+strip_hints = true
+```
+
+Set `strip_hints = false` only when an interactive client should surface those advisory fields directly to the user.
+
+## Review Before Writing
+
+Before saving a memory, ask:
+
+- Will this still matter next week?
+- Is the source or reason clear?
+- Could this be harmful if recalled out of context?
+- Does it contain sensitive or private data?
+- Should this be attached to a specific project brain instead of a global brain?
+
+Use `nmem check` for sensitive content before storing uncertain text:
+
+```bash
+nmem check "candidate memory text"
+```
+
+## Correct And Retire Stale Memories
+
+Treat memory as a maintained project artifact. When facts change, add a correcting memory with the new source and date. For stale or harmful content, edit, forget, or use lifecycle controls rather than relying on future agents to infer that it is obsolete.
+
+Useful review commands:
+
+```bash
+nmem status
+nmem stats
+nmem context --fresh-only
+nmem recall "old decision" --show-age
+```
+
+## Suggested Agent Policy
+
+For coding agents, a conservative default policy is:
+
+- Store decisions, constraints, and confirmed user preferences.
+- Store fixes only when the cause and resolution are clear.
+- Do not store secrets or raw logs.
+- Do not store every command result.
+- Prefer project-specific brains for project facts.
+- Use JSON or compact MCP output when piping memory back into prompts.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,6 +98,7 @@ nav:
     - Brain Sharing: guides/brain-sharing.md
     - Multi-Brain Setup: guides/multi-brain-setup.md
     - Brain Health Guide: guides/brain-health.md
+    - Agent Memory Governance: guides/agent-memory-governance.md
     - OpenClaw Plugin: guides/openclaw-plugin.md
     - Cognitive Reasoning: guides/cognitive-reasoning.md
     - Schema v21 Migration: guides/schema-v21-migration.md

--- a/src/neural_memory/cli/main.py
+++ b/src/neural_memory/cli/main.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sys
+from collections.abc import Sequence
 from typing import Annotated
 
 import typer
@@ -11,6 +13,15 @@ app = typer.Typer(
     name="nmem",
     help="Neural Memory - Reflex-based memory for AI agents",
     no_args_is_help=True,
+)
+
+_MACHINE_ORIENTED_UPDATE_CHECK_SKIP_COMMANDS = frozenset(
+    {
+        "context",
+        "recall",
+        "stats",
+        "status",
+    }
 )
 
 
@@ -41,6 +52,20 @@ def _warn_if_not_initialized(ctx: typer.Context) -> None:
         )
 
 
+def _args_request_json(args: Sequence[str]) -> bool:
+    """Return True when the raw CLI invocation requests JSON output."""
+    return any(arg in {"--json", "-j"} or arg.startswith("--json=") for arg in args)
+
+
+def _should_run_update_check(ctx: typer.Context, args: Sequence[str] | None = None) -> bool:
+    """Decide whether this command should emit opportunistic update notices."""
+    if ctx.invoked_subcommand in _MACHINE_ORIENTED_UPDATE_CHECK_SKIP_COMMANDS:
+        return False
+
+    raw_args = sys.argv[1:] if args is None else args
+    return not _args_request_json(raw_args)
+
+
 @app.callback(invoke_without_command=True)
 def _app_callback(
     ctx: typer.Context,
@@ -60,6 +85,9 @@ def _app_callback(
         return
 
     _warn_if_not_initialized(ctx)
+
+    if not _should_run_update_check(ctx):
+        return
 
     from neural_memory.cli.update_check import run_update_check_background
 

--- a/src/neural_memory/mcp/response_compactor.py
+++ b/src/neural_memory/mcp/response_compactor.py
@@ -149,6 +149,34 @@ def compact_response(
     return out
 
 
+def strip_response_hints(result: dict[str, Any], config: ResponseConfig) -> dict[str, Any]:
+    """Strip advisory hint fields without applying full compaction.
+
+    This preserves normal response shape while honoring ``response.strip_hints``
+    for machine clients that do not request compact mode.
+    """
+    if not config.strip_hints or not isinstance(result, dict):
+        return result
+
+    out: dict[str, Any] = {}
+    changed = False
+
+    for key, value in result.items():
+        if key in STRIPPABLE_KEYS:
+            changed = True
+            continue
+
+        if isinstance(value, dict):
+            stripped = strip_response_hints(value, config)
+            out[key] = stripped
+            changed = changed or stripped is not value
+            continue
+
+        out[key] = value
+
+    return out if changed else result
+
+
 def should_compact(
     *,
     tool_args: dict[str, Any],

--- a/src/neural_memory/mcp/server.py
+++ b/src/neural_memory/mcp/server.py
@@ -549,6 +549,7 @@ async def handle_message(server: MCPServer, message: dict[str, Any]) -> dict[str
             compact_response,
             needs_auto_compact,
             should_compact,
+            strip_response_hints,
         )
 
         use_compact = should_compact(tool_args=tool_args, config=server.config.response)
@@ -574,6 +575,8 @@ async def handle_message(server: MCPServer, message: dict[str, Any]) -> dict[str
                 elif needs_auto_compact(result, resp_config.auto_compact_threshold):
                     logger.debug("Auto-compact: %s exceeded threshold", tool_name)
                     result = compact_response(result, resp_config)
+                else:
+                    result = strip_response_hints(result, resp_config)
 
                 # Apply token budget if requested
                 if token_budget is not None:

--- a/tests/unit/test_cli_update_notice_policy.py
+++ b/tests/unit/test_cli_update_notice_policy.py
@@ -1,0 +1,77 @@
+"""Tests for CLI update notice routing and suppression."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from neural_memory.cli.main import _args_request_json, _should_run_update_check, app
+
+runner = CliRunner()
+
+
+class TestUpdateNoticePolicy:
+    """Tests for opportunistic update-check command policy."""
+
+    def test_json_flags_skip_update_check(self) -> None:
+        ctx = MagicMock(invoked_subcommand="check")
+
+        assert _should_run_update_check(ctx, ["check", "safe", "--json"]) is False
+        assert _should_run_update_check(ctx, ["check", "safe", "-j"]) is False
+        assert _should_run_update_check(ctx, ["check", "safe", "--json=true"]) is False
+
+    def test_machine_oriented_commands_skip_update_check(self) -> None:
+        for command in ("context", "recall", "stats", "status"):
+            ctx = MagicMock(invoked_subcommand=command)
+            assert _should_run_update_check(ctx, [command]) is False
+
+    def test_interactive_commands_allow_update_check(self) -> None:
+        ctx = MagicMock(invoked_subcommand="check")
+
+        assert _should_run_update_check(ctx, ["check", "safe"]) is True
+
+    def test_json_flag_detection(self) -> None:
+        assert _args_request_json(["doctor", "--json"]) is True
+        assert _args_request_json(["doctor", "-j"]) is True
+        assert _args_request_json(["doctor", "--json=true"]) is True
+        assert _args_request_json(["doctor"]) is False
+
+
+class TestUpdateNoticeOutput:
+    """Tests that notices do not contaminate machine-readable output."""
+
+    def test_json_cli_output_stays_clean(self) -> None:
+        with (
+            patch("sys.argv", ["nmem", "check", "plain text", "--json"]),
+            patch("neural_memory.cli.main._warn_if_not_initialized"),
+            patch("neural_memory.cli.update_check.run_update_check_background") as mock_start,
+        ):
+            result = runner.invoke(app, ["check", "plain text", "--json"])
+
+        assert result.exit_code == 0
+        assert mock_start.call_count == 0
+        payload = json.loads(result.stdout)
+        assert payload == {"sensitive": False, "matches": []}
+
+    def test_non_json_cli_can_start_background_update_check(self) -> None:
+        with (
+            patch("sys.argv", ["nmem", "check", "plain text"]),
+            patch("neural_memory.cli.main._warn_if_not_initialized"),
+            patch("neural_memory.cli.update_check.run_update_check_background") as mock_start,
+        ):
+            result = runner.invoke(app, ["check", "plain text"])
+
+        assert result.exit_code == 0
+        mock_start.assert_called_once_with()
+
+    def test_update_notice_prints_to_stderr_only(self, capsys) -> None:  # type: ignore[no-untyped-def]
+        from neural_memory.cli.update_check import _print_update_notice
+
+        with patch("neural_memory.cli.update_check._is_editable_install", return_value=False):
+            _print_update_notice("1.0.0", "1.1.0")
+
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "Update available" in captured.err

--- a/tests/unit/test_response_compactor.py
+++ b/tests/unit/test_response_compactor.py
@@ -10,6 +10,7 @@ from neural_memory.mcp.response_compactor import (
     compact_response,
     needs_auto_compact,
     should_compact,
+    strip_response_hints,
 )
 from neural_memory.unified_config import ResponseConfig
 
@@ -145,6 +146,55 @@ class TestCompactResponseEdgeCases:
         compacted = compact_response(result, _default_config(max_list_items=3))
         assert compacted["items"] == [1, 2, 3]
         assert "_items_truncated" not in compacted
+
+
+# ---------- strip_response_hints ----------
+
+
+class TestStripResponseHints:
+    """Test hint-only stripping without compacting the response."""
+
+    def test_strips_hints_without_truncating_lists(self) -> None:
+        result = {
+            "answer": "keep",
+            "maintenance_hint": "strip",
+            "memories": [{"id": i} for i in range(20)],
+        }
+
+        stripped = strip_response_hints(result, ResponseConfig(strip_hints=True))
+
+        assert stripped["answer"] == "keep"
+        assert "maintenance_hint" not in stripped
+        assert stripped["memories"] == result["memories"]
+        assert "_memories_truncated" not in stripped
+
+    def test_strips_nested_hints(self) -> None:
+        result = {
+            "data": {
+                "answer": "keep",
+                "update_hint": "strip",
+                "onboarding": {"next": "strip"},
+            }
+        }
+
+        stripped = strip_response_hints(result, ResponseConfig(strip_hints=True))
+
+        assert stripped["data"] == {"answer": "keep"}
+
+    def test_preserves_hints_when_disabled(self) -> None:
+        result = {"answer": "keep", "update_hint": "keep"}
+
+        stripped = strip_response_hints(result, ResponseConfig(strip_hints=False))
+
+        assert stripped is result
+        assert stripped["update_hint"] == "keep"
+
+    def test_returns_original_when_no_hints_found(self) -> None:
+        result = {"answer": "keep", "confidence": 0.9}
+
+        stripped = strip_response_hints(result, ResponseConfig(strip_hints=True))
+
+        assert stripped is result
 
 
 # ---------- should_compact ----------


### PR DESCRIPTION
## Summary

Keeps package-update and advisory hints out of machine-consumed CLI and MCP output by default, and adds agent memory governance documentation.

## Why

Agents commonly feed `nmem context`, `status`, `stats`, `recall`, JSON CLI output, and MCP responses back into prompts. Human-facing update banners and advisory hints can pollute summaries and memory captures even when the command's actual result is structured and parseable.

## Changes

- Skip opportunistic CLI update checks when the invocation requests `--json` or `-j`.
- Skip opportunistic CLI update checks for machine-oriented commands: `context`, `recall`, `stats`, and `status`.
- Keep existing update notices on stderr for interactive commands that still run the check.
- Make MCP `response.strip_hints = true` strip advisory hint fields even when compact mode is off, preserving the rest of the response shape.
- Add tests for CLI update-notice policy and MCP hint-only stripping.
- Add an Agent Memory Governance guide and link it in the docs nav.

## Verification

- `ruff check src/neural_memory/cli/main.py tests/unit/test_cli_update_notice_policy.py`
- `pytest tests/unit/test_cli_update_notice_policy.py -q`
- `PATH=/home/asiphyx/neural-memory/.venv/bin:$PATH pytest tests/unit/test_update_command.py tests/unit/test_cli_update_notice_policy.py -q`
- `ruff check src/neural_memory/mcp/response_compactor.py src/neural_memory/mcp/server.py tests/unit/test_response_compactor.py`
- `pytest tests/unit/test_response_compactor.py -q`
- `nmem check "plain text" --json`

I could not run `mkdocs build --strict` locally because `mkdocs` is not installed in the current venv.
