### PR TITLE
fix(encoding): filter noisy concept neurons from short and low-signal text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — Concept Neuron Noise Filtering (#156)
+
+Short and casual text no longer creates low-signal concept neurons that pollute
+recall context. `ExtractConceptNeuronsStep` now:
+
+- Raises min keyword length from 3 to 4 chars (filters `AI`, `OS`, `It`)
+- Scales concept floor from 5 to 3 for content under 100 chars
+- Skips keywords already captured as entity neurons (avoids duplicates)
+- Filters known noise words (`use`, `run`, `new`, `got`, etc.)
+
+Aligns with the F2 Fiber Precision & Density roadmap item.
+
 ### Fixed — Advisory hints stripped from machine output (#155)
 
 CLI update notices are now skipped for machine-oriented commands

--- a/src/neural_memory/engine/pipeline_steps.py
+++ b/src/neural_memory/engine/pipeline_steps.py
@@ -300,6 +300,36 @@ async def _find_similar_entity(storage: NeuralStorage, text: str) -> Neuron | No
 # ── Step 3: Extract Concept Neurons ──
 
 
+# Short common words that produce noisy concept neurons.
+# These match len >= 3 but carry no topical signal.
+_NOISE_CONCEPTS: frozenset[str] = frozenset(
+    {
+        # Pronouns / determiners that survive stop-word filtering
+        "not",
+        "but",
+        "all",
+        "any",
+        "can",
+        "get",
+        "got",
+        # Very common verbs
+        "use",
+        "used",
+        "let",
+        "run",
+        "try",
+        "see",
+        "say",
+        # Common adjectives / adverbs
+        "new",
+        "old",
+        "own",
+        "way",
+        "too",
+    }
+)
+
+
 class ExtractConceptNeuronsStep:
     """Extract keyword/concept neurons from content."""
 
@@ -314,10 +344,30 @@ class ExtractConceptNeuronsStep:
         config: BrainConfig,
     ) -> PipelineContext:
         keywords = extract_keywords(ctx.content, language=ctx.language)
-        concept_limit = min(20, max(5, len(ctx.content) // 100))
+        # Scale concept floor to content length: short text (<100 chars)
+        # rarely carries enough signal for 5+ distinct concepts.
+        concept_limit = min(20, max(3, len(ctx.content) // 100))
+
+        # Build a set of entity content already captured so concept extraction
+        # doesn't duplicate what entity neurons already represent.
+        entity_content = {
+            n.content.lower() for n in ctx.entity_neurons + ctx.existing_entity_neurons
+        }
+
+        def _is_valid_concept(kw: str) -> bool:
+            kw_lower = kw.lower()
+            # Minimum 4 chars — 3-char words produce too many noise concepts ("ai", "os")
+            if len(kw_lower) < 4:
+                return False
+            if kw_lower in _NOISE_CONCEPTS:
+                return False
+            # Skip if already captured as an entity neuron
+            if kw_lower in entity_content:
+                return False
+            return True
 
         # Filter valid keywords first
-        valid_keywords = [kw for kw in keywords[:concept_limit] if len(kw) >= 3]
+        valid_keywords = [kw for kw in keywords[:concept_limit] if _is_valid_concept(kw)]
 
         # Batch check existing concepts in one query
         existing_map = await storage.find_neurons_exact_batch(

--- a/tests/unit/test_concept_noise_filter.py
+++ b/tests/unit/test_concept_noise_filter.py
@@ -1,0 +1,133 @@
+"""Tests for concept neuron noise filtering.
+
+Verifies that the ExtractConceptNeuronsStep avoids creating low-signal
+concept neurons from short common words, entity duplicates, and
+3-char noise that survives keyword extraction.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from neural_memory.core.brain import Brain, BrainConfig
+from neural_memory.core.neuron import NeuronType
+from neural_memory.engine.encoder import MemoryEncoder
+from neural_memory.storage.memory_store import InMemoryStorage
+
+
+@pytest.fixture
+async def encoder() -> tuple[MemoryEncoder, InMemoryStorage]:
+    """Create an encoder with in-memory storage."""
+    storage = InMemoryStorage()
+    config = BrainConfig()
+    brain = Brain.create(name="test", config=config)
+    await storage.save_brain(brain)
+    storage.set_brain(brain.id)
+    return MemoryEncoder(storage, brain.config), storage
+
+
+class TestConceptNoiseFilter:
+    """Concept neurons should exclude short noise words."""
+
+    @pytest.mark.asyncio
+    async def test_no_concept_from_short_noise_words(
+        self, encoder: tuple[MemoryEncoder, InMemoryStorage]
+    ) -> None:
+        """3-char words like 'AI', 'OS', 'the' should not become concept neurons."""
+        enc, _storage = encoder
+
+        result = await enc.encode(
+            "The AI system has a new OS running",
+            timestamp=datetime(2024, 2, 4, 15, 0),
+        )
+
+        concept_contents = {
+            n.content.lower() for n in result.neurons_created if n.type == NeuronType.CONCEPT
+        }
+        # "AI" and "OS" are 2-3 chars and should be filtered out
+        assert "ai" not in concept_contents
+        assert "os" not in concept_contents
+
+    @pytest.mark.asyncio
+    async def test_short_content_gets_fewer_concepts(
+        self, encoder: tuple[MemoryEncoder, InMemoryStorage]
+    ) -> None:
+        """Short text (<50 chars) should produce at most 3 concept neurons."""
+        enc, _storage = encoder
+
+        result = await enc.encode(
+            "Fixed a bug",
+            timestamp=datetime(2024, 2, 4, 15, 0),
+        )
+
+        concept_count = sum(1 for n in result.neurons_created if n.type == NeuronType.CONCEPT)
+        assert concept_count <= 3, f"Short text produced {concept_count} concepts, expected <= 3"
+
+    @pytest.mark.asyncio
+    async def test_entity_not_duplicated_as_concept(
+        self, encoder: tuple[MemoryEncoder, InMemoryStorage]
+    ) -> None:
+        """Words already captured as entity neurons should not also become concepts."""
+        enc, _storage = encoder
+
+        result = await enc.encode(
+            "Met Alice at the Redis deployment meeting",
+            timestamp=datetime(2024, 2, 4, 15, 0),
+        )
+
+        entity_contents = {
+            n.content.lower()
+            for n in result.neurons_created
+            if n.type in (NeuronType.ENTITY, NeuronType.CONCEPT) and n.type != NeuronType.CONCEPT
+        }
+        concept_contents = {
+            n.content.lower() for n in result.neurons_created if n.type == NeuronType.CONCEPT
+        }
+        # No overlap between entities and concepts
+        overlap = entity_contents & concept_contents
+        assert not overlap, f"Entities duplicated as concepts: {overlap}"
+
+    @pytest.mark.asyncio
+    async def test_noise_concept_set_filtered(
+        self, encoder: tuple[MemoryEncoder, InMemoryStorage]
+    ) -> None:
+        """Known noise words ('use', 'run', 'new', etc.) should not become concepts."""
+        enc, _storage = encoder
+
+        result = await enc.encode(
+            "We use the new tool to run the test",
+            timestamp=datetime(2024, 2, 4, 15, 0),
+        )
+
+        concept_contents = {
+            n.content.lower() for n in result.neurons_created if n.type == NeuronType.CONCEPT
+        }
+        for noise_word in ("use", "run", "new"):
+            assert noise_word not in concept_contents, (
+                f"Noise word '{noise_word}' became a concept neuron"
+            )
+
+    @pytest.mark.asyncio
+    async def test_meaningful_concepts_still_created(
+        self, encoder: tuple[MemoryEncoder, InMemoryStorage]
+    ) -> None:
+        """Meaningful multi-char concepts should still be created normally."""
+        enc, _storage = encoder
+
+        result = await enc.encode(
+            "Decided to use PostgreSQL for the caching layer instead of Redis",
+            timestamp=datetime(2024, 2, 4, 15, 0),
+        )
+
+        concept_contents = {
+            n.content.lower() for n in result.neurons_created if n.type == NeuronType.CONCEPT
+        }
+        # Keywords may be bigrams — check that meaningful terms appear as
+        # substrings in concept content rather than exact matches.
+        meaningful = ["caching", "postgresql", "redis"]
+        found = [term for term in meaningful if any(term in c for c in concept_contents)]
+        assert found, (
+            f"Expected at least one meaningful concept from {meaningful}, got {concept_contents}"
+        )


### PR DESCRIPTION
## Summary

`ExtractConceptNeuronsStep` now filters out low-signal concept neurons that pollute recall context with noise like `AI`, `OS`, `use`, `run`, and entity duplicates.

## Why

Concept extraction currently uses `len(kw) >= 3` and a floor of 5 concepts per memory. This produces garbage concept neurons from casual text:

- 3-char words: `AI`, `OS`, `It` survive the filter but carry no topical signal
- Known filler: `use`, `run`, `new`, `got` pass keyword extraction but add nothing
- Entity duplication: `Redis` gets both an entity neuron AND a concept neuron
- Short text over-extraction: a 40-char sentence generates 5 concepts from maybe 2 meaningful signals

This directly addresses the **F2 Fiber Precision & Density** roadmap item — improving content density per character.

## Changes

- Raise min keyword length from 3 to 4 chars in concept extraction
- Scale concept floor from 5 to 3 for content under 100 chars
- Skip keywords already captured as entity neurons (dedup entity ↔ concept)
- Add `_NOISE_CONCEPTS` set for common words that survive keyword extraction but carry no signal
- 5 new tests covering all filter paths

## Verification

```
ruff check src/neural_memory/engine/pipeline_steps.py tests/unit/test_concept_noise_filter.py
mypy src/neural_memory/engine/pipeline_steps.py
pytest tests/unit/test_concept_noise_filter.py -v
pytest tests/unit/test_auto_tags.py tests/unit/test_pattern_extraction.py tests/unit/test_code_semantic.py -v
```

All 5 new + 70 existing tests pass. ruff + mypy clean.

## Scope

One pipeline step. No API changes. No breaking changes to storage, retrieval, or recall.