### PR TITLE
fix(consolidation): prevent tag-repetition pollution loop in _summarize and _essence_backfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — Consolidation summary_fiber self-amplifying pollution loop
+
+- **`_summarize()` no longer creates tag-repetition pollution.** The method now
+  excludes existing `summary_fiber` entries from the clustering pool to prevent
+  a self-amplifying loop where each cycle re-ingested the previous cycle's output.
+- **Tag-repetition pattern detection.** Source fiber summaries matching the
+  signature `[tag1, tag2] [tag1, tag2] ...` are now filtered out before
+  constructing the cluster's concept content, preventing nested bracket pollution.
+- **`_essence_backfill()` rejects polluted anchor content.** The same
+  tag-repetition pattern check is applied to anchor neuron content before
+  generating essence, preventing propagation of pollution into the essence field.
+
 ## [4.59.1] — 2026-07-22
 
 ### Fixed — Codex hook installer wrote a matcher Codex cannot compile

--- a/src/neural_memory/engine/consolidation.py
+++ b/src/neural_memory/engine/consolidation.py
@@ -1099,7 +1099,14 @@ class ConsolidationEngine:
         if len(fibers) < self._config.summarize_min_cluster_size:
             return
 
-        fiber_list = [f for f in fibers if f.tags]
+        # Exclude existing summary_fibers to prevent self-amplifying pollution loop.
+        # Summary fibers carry the same tags as their source cluster, so they would
+        # be re-ingested on the next cycle, compounding any pollution exponentially.
+        fiber_list = [
+            f for f in fibers
+            if f.tags
+            and f.metadata.get("_consolidation") != "summary_fiber"
+        ]
 
         # Cap fiber count for O(N²) pair comparison — keep highest-salience
         max_fibers_for_clustering = 1000
@@ -1174,14 +1181,28 @@ class ConsolidationEngine:
 
             cluster_fibers = [fiber_list[i] for i in members]
 
-            summaries = [f.summary for f in cluster_fibers if f.summary]
+            # Filter out fibers whose summary matches the tag-repetition pollution
+            # pattern (e.g., "[tag1, tag2] [tag1, tag2] [tag1, tag2] ...")
+            _tag_pollution_re = None
+            import re as _re_summ
+
+            _tag_pollution_re = _re_summ.compile(r'^\[.+\](?:\s*\[.+\])+')
+
+            raw_summaries = []
+            for f in cluster_fibers:
+                if f.summary and not _tag_pollution_re.match(f.summary):
+                    raw_summaries.append(f.summary)
+
+            # Deduplicate before joining to reduce redundancy
+            unique_summaries = list(dict.fromkeys(raw_summaries))
+
             all_tags: set[str] = set()
             for f in cluster_fibers:
                 all_tags |= f.tags
 
             summary_content = (
-                "; ".join(summaries[:10])
-                if summaries
+                "; ".join(unique_summaries[:10])
+                if unique_summaries
                 else f"Cluster of {len(cluster_fibers)} memories"
             )
             tag_label = ", ".join(sorted(all_tags)[:5])
@@ -1395,6 +1416,19 @@ class ConsolidationEngine:
 
             anchor = await self._storage.get_neuron(fiber.anchor_neuron_id)
             if not anchor or not anchor.content:
+                continue
+
+            # Reject anchor content that matches tag-repetition pollution
+            # (same defence as _summarize — prevents essence backfill from
+            #  propagating garbage through the generator into the fiber)
+            import re as _re_bl
+
+            if _re_bl.match(r'^\[.+\](?:\s*\[.+\])+', anchor.content):
+                logger.debug(
+                    "Skipping essence backfill for fiber %s: anchor content "
+                    "matches tag-repetition pattern",
+                    fiber.id,
+                )
                 continue
 
             # Get priority from typed memory for cost guard

--- a/src/neural_memory/engine/consolidation.py
+++ b/src/neural_memory/engine/consolidation.py
@@ -48,6 +48,13 @@ _CAUSAL_SYNAPSE_TYPES = frozenset(
     }
 )
 
+# Tag-repetition pollution signature: content that is nothing but two or more
+# adjacent bracketed groups (e.g. "[tag1, tag2] [tag1, tag2] …"). Produced by
+# older _summarize cycles that re-ingested their own "[tags] summary" output —
+# each pass nested the previous pass's bracket prefix, compounding exponentially.
+# Used to keep polluted summaries out of new concept content and essence backfill.
+_TAG_POLLUTION_RE = re.compile(r"^\[.+\](?:\s*\[.+\])+")
+
 
 class ConsolidationStrategy(StrEnum):
     """Available consolidation strategies."""
@@ -1103,9 +1110,7 @@ class ConsolidationEngine:
         # Summary fibers carry the same tags as their source cluster, so they would
         # be re-ingested on the next cycle, compounding any pollution exponentially.
         fiber_list = [
-            f for f in fibers
-            if f.tags
-            and f.metadata.get("_consolidation") != "summary_fiber"
+            f for f in fibers if f.tags and f.metadata.get("_consolidation") != "summary_fiber"
         ]
 
         # Cap fiber count for O(N²) pair comparison — keep highest-salience
@@ -1182,19 +1187,14 @@ class ConsolidationEngine:
             cluster_fibers = [fiber_list[i] for i in members]
 
             # Filter out fibers whose summary matches the tag-repetition pollution
-            # pattern (e.g., "[tag1, tag2] [tag1, tag2] [tag1, tag2] ...")
-            _tag_pollution_re = None
-            import re as _re_summ
-
-            _tag_pollution_re = _re_summ.compile(r'^\[.+\](?:\s*\[.+\])+')
-
-            raw_summaries = []
-            for f in cluster_fibers:
-                if f.summary and not _tag_pollution_re.match(f.summary):
-                    raw_summaries.append(f.summary)
-
-            # Deduplicate before joining to reduce redundancy
-            unique_summaries = list(dict.fromkeys(raw_summaries))
+            # pattern, then dedup before joining to reduce redundancy.
+            unique_summaries = list(
+                dict.fromkeys(
+                    f.summary
+                    for f in cluster_fibers
+                    if f.summary and not _TAG_POLLUTION_RE.match(f.summary)
+                )
+            )
 
             all_tags: set[str] = set()
             for f in cluster_fibers:
@@ -1420,10 +1420,8 @@ class ConsolidationEngine:
 
             # Reject anchor content that matches tag-repetition pollution
             # (same defence as _summarize — prevents essence backfill from
-            #  propagating garbage through the generator into the fiber)
-            import re as _re_bl
-
-            if _re_bl.match(r'^\[.+\](?:\s*\[.+\])+', anchor.content):
+            # propagating garbage through the generator into the fiber)
+            if _TAG_POLLUTION_RE.match(anchor.content):
                 logger.debug(
                     "Skipping essence backfill for fiber %s: anchor content "
                     "matches tag-repetition pattern",

--- a/tests/unit/test_consolidation_tag_pollution.py
+++ b/tests/unit/test_consolidation_tag_pollution.py
@@ -1,0 +1,190 @@
+"""Regression tests for the summary_fiber tag-repetition pollution loop (PR #194).
+
+_summarize() used to re-ingest its own summary fibers: they carry the same tags
+as their source cluster, so each cycle nested the previous cycle's "[tags] …"
+prefix into the new concept content — compounding exponentially. These tests pin:
+
+1. summary_fiber entries are excluded from the clustering pool,
+2. polluted "[tags] [tags] …" summaries never reach new concept content,
+3. duplicate summaries are deduped before joining,
+4. _essence_backfill skips anchors whose content matches the pollution pattern.
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+
+from neural_memory.core.brain import Brain
+from neural_memory.core.fiber import Fiber
+from neural_memory.core.neuron import Neuron, NeuronType
+from neural_memory.engine.consolidation import (
+    _TAG_POLLUTION_RE,
+    ConsolidationEngine,
+    ConsolidationStrategy,
+)
+from neural_memory.storage.memory_store import InMemoryStorage
+
+POLLUTED_SUMMARY = "[character, novel] [character, novel] [character, novel]"
+
+
+@pytest_asyncio.fixture
+async def storage() -> InMemoryStorage:
+    store = InMemoryStorage()
+    brain = Brain.create(name="pollution_test", brain_id="pollution-brain")
+    await store.save_brain(brain)
+    store.set_brain(brain.id)
+    return store
+
+
+async def _add_fiber(
+    store: InMemoryStorage,
+    idx: int,
+    *,
+    summary: str,
+    tags: set[str],
+    metadata: dict | None = None,
+) -> Fiber:
+    anchor = Neuron.create(
+        type=NeuronType.ENTITY,
+        content=f"anchor content {idx}",
+        neuron_id=f"n-{idx}",
+    )
+    await store.add_neuron(anchor)
+    fiber = Fiber.create(
+        neuron_ids={anchor.id},
+        synapse_ids=set(),
+        anchor_neuron_id=anchor.id,
+        summary=summary,
+        tags=tags,
+        metadata=metadata or {},
+        fiber_id=f"fiber-{idx}",
+    )
+    await store.add_fiber(fiber)
+    return fiber
+
+
+class TestTagPollutionRegex:
+    def test_matches_repeated_tag_groups(self) -> None:
+        assert _TAG_POLLUTION_RE.match(POLLUTED_SUMMARY)
+        assert _TAG_POLLUTION_RE.match("[a] [b]")
+        assert _TAG_POLLUTION_RE.match("[x, y]  [x, y] trailing text")
+
+    def test_does_not_match_single_bracket_prefix(self) -> None:
+        # The legitimate "[tags] summary" format has exactly one bracket group.
+        assert not _TAG_POLLUTION_RE.match("[api, auth] Fixed the login bug")
+        assert not _TAG_POLLUTION_RE.match("plain summary text")
+        assert not _TAG_POLLUTION_RE.match("[only one] then text with [brackets] later")
+
+
+@pytest.mark.asyncio
+async def test_summary_fiber_excluded_from_clustering(storage: InMemoryStorage) -> None:
+    """Existing summary fibers must not be re-ingested into new clusters."""
+    tags = {"character", "novel"}
+    for i in range(3):
+        await _add_fiber(storage, i, summary=f"source summary {i}", tags=tags)
+    old_summary = await _add_fiber(
+        storage,
+        99,
+        summary=POLLUTED_SUMMARY,
+        tags=tags,
+        metadata={"_consolidation": "summary_fiber", "source_fibers": []},
+    )
+
+    engine = ConsolidationEngine(storage)
+    await engine.run(strategies=[ConsolidationStrategy.SUMMARIZE])
+
+    new_summary_fibers = [
+        f
+        for f in await storage.get_fibers(limit=1000)
+        if f.metadata.get("_consolidation") == "summary_fiber" and f.id != old_summary.id
+    ]
+    assert new_summary_fibers, "expected a new summary fiber for the cluster"
+    for fiber in new_summary_fibers:
+        assert old_summary.id not in fiber.metadata.get("source_fibers", [])
+        assert POLLUTED_SUMMARY not in (fiber.summary or "")
+
+
+@pytest.mark.asyncio
+async def test_polluted_summary_filtered_from_concept_content(
+    storage: InMemoryStorage,
+) -> None:
+    """A source fiber with a polluted summary must not leak into concept content."""
+    tags = {"alpha", "beta"}
+    await _add_fiber(storage, 0, summary=POLLUTED_SUMMARY, tags=tags)
+    await _add_fiber(storage, 1, summary="clean summary one", tags=tags)
+    await _add_fiber(storage, 2, summary="clean summary two", tags=tags)
+
+    engine = ConsolidationEngine(storage)
+    await engine.run(strategies=[ConsolidationStrategy.SUMMARIZE])
+
+    concepts = [
+        n
+        for n in (await storage.find_neurons(type=NeuronType.CONCEPT))
+        if n.metadata.get("_consolidation") == "summary"
+    ]
+    assert concepts, "expected a concept neuron for the cluster"
+    for concept in concepts:
+        assert POLLUTED_SUMMARY not in concept.content
+        assert "clean summary one" in concept.content
+
+
+@pytest.mark.asyncio
+async def test_duplicate_summaries_deduped(storage: InMemoryStorage) -> None:
+    """Identical member summaries appear once in the joined concept content."""
+    tags = {"gamma", "delta"}
+    for i in range(3):
+        await _add_fiber(storage, i, summary="repeated summary", tags=tags)
+
+    engine = ConsolidationEngine(storage)
+    await engine.run(strategies=[ConsolidationStrategy.SUMMARIZE])
+
+    concepts = [
+        n
+        for n in (await storage.find_neurons(type=NeuronType.CONCEPT))
+        if n.metadata.get("_consolidation") == "summary"
+    ]
+    assert concepts
+    for concept in concepts:
+        assert concept.content.count("repeated summary") == 1
+
+
+@pytest.mark.asyncio
+async def test_essence_backfill_skips_polluted_anchor(storage: InMemoryStorage) -> None:
+    """Anchors whose content matches the pollution pattern get no essence."""
+    polluted_anchor = Neuron.create(
+        type=NeuronType.CONCEPT,
+        content=POLLUTED_SUMMARY,
+        neuron_id="n-polluted",
+    )
+    clean_anchor = Neuron.create(
+        type=NeuronType.ENTITY,
+        content="The deploy failed because the API key expired. Rotating it fixed CI.",
+        neuron_id="n-clean",
+    )
+    await storage.add_neuron(polluted_anchor)
+    await storage.add_neuron(clean_anchor)
+    polluted_fiber = Fiber.create(
+        neuron_ids={polluted_anchor.id},
+        synapse_ids=set(),
+        anchor_neuron_id=polluted_anchor.id,
+        summary="polluted",
+        fiber_id="fiber-polluted",
+    )
+    clean_fiber = Fiber.create(
+        neuron_ids={clean_anchor.id},
+        synapse_ids=set(),
+        anchor_neuron_id=clean_anchor.id,
+        summary="clean",
+        fiber_id="fiber-clean",
+    )
+    await storage.add_fiber(polluted_fiber)
+    await storage.add_fiber(clean_fiber)
+
+    engine = ConsolidationEngine(storage)
+    await engine.run(strategies=[ConsolidationStrategy.ESSENCE_BACKFILL])
+
+    refreshed_polluted = await storage.get_fiber("fiber-polluted")
+    refreshed_clean = await storage.get_fiber("fiber-clean")
+    assert refreshed_polluted is not None and not refreshed_polluted.essence
+    assert refreshed_clean is not None and refreshed_clean.essence


### PR DESCRIPTION
## Changes

- **`_summarize()` now excludes existing `summary_fiber` entries from the clustering pool.** Previously, the filter at L1102 only checked `f.tags` — it did not exclude fibers whose `metadata["_consolidation"] == "summary_fiber"`. Since summary fibers carry the same tags as their source cluster, they would be re-ingested on the next cycle, compounding any pollution exponentially.

- **Tag-repetition pattern detection added to `_summarize()`.** Source fiber summaries matching the signature `[tag1, tag2] [tag1, tag2] ...` (e.g., `[character, novel, personality, psychology] [character, novel, personality, psychology]`) are now filtered out before constructing the cluster's concept content. This prevents the nested bracket pollution that previously doubled with each consolidation cycle.

- **`_essence_backfill()` now rejects polluted anchor content.** The same tag-repetition pattern check is applied to anchor neuron content before generating essence. Previously, the extractive essence generator would treat the polluted tag-repetition string as a valid single sentence (no sentence boundaries like `.`, `!`, `?`) and propagate the garbage into the fiber's `essence` field.

- **Summaries are deduplicated before joining** (`dict.fromkeys()`) to reduce redundancy when multiple cluster members share identical summaries.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Tests

## Testing

Describe how you tested these changes:

- [x] Unit tests added/updated (existing test suite: 1869 passed, 0 failures related to this change)
- [ ] Integration tests added/updated
- [x] Manual testing performed (`nmem recall returns clean memory data instead of repeating tag lists after the fix)

## Checklist

- [x] My code follows the project's style guidelines (ruff: all checks passed)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] I have updated CHANGELOG.md

## Related Issues

No related issue — discovered during local testing after upgrading to v4.59.1.
