### PR TITLE
fix(scripts): prune the two surfaces that still leaked, and share the marker logic

### DIFF
--- a/scripts/_prune_status.py
+++ b/scripts/_prune_status.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Shared exclusion-marker logic for the `prune-*.py` maintenance scripts.
+
+WHY THIS MODULE EXISTS
+----------------------
+Hiding a neuron from recall means setting ``metadata._status``. It does NOT
+mean setting the ``lifecycle_state`` column, for two independent reasons:
+
+1. No retrieval path reads that column. ``row_to_neuron`` ignores it entirely;
+   visibility is gated by ``Neuron.status`` (from ``metadata._status``) via
+   ``_filter_by_status`` in ``engine/retrieval.py``, which default-allows only
+   ``'active'``.
+2. The column is derived, not user-settable. The ``lifecycle`` consolidation
+   strategy recomputes it from heat and age for EVERY neuron on every run
+   (``engine/consolidation.py``), so any value written here is overwritten by
+   the next consolidation pass.
+
+Both prune scripts originally wrote only ``lifecycle_state``, so everything
+they "pruned" stayed fully recallable — and on a real brain the marker had
+already been erased by consolidation. The logic lived in two copies, which is
+why the same bug existed twice; it lives here now so a third script cannot
+repeat it.
+
+See issue #195.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+# Statuses that already hide a neuron from default recall. A row in one of
+# these is left alone, which also makes re-running a prune idempotent.
+ALREADY_HIDDEN = ("expired", "superseded")
+
+# Predicate for "this row is still visible to recall". Callers AND their own
+# match condition onto it. Deliberately keyed on `_status`, not on
+# `lifecycle_state` — re-running therefore also repairs rows that an older
+# version of a script marked `stale` without setting `_status`.
+STILL_VISIBLE_SQL = (
+    "COALESCE(json_extract(metadata, '$._status'), 'active') NOT IN ('expired', 'superseded')"
+)
+
+# Sets the marker recall actually reads, stashing the prior value so a restore
+# is faithful rather than assuming everything was 'active'. `lifecycle_state`
+# is still written for continuity with earlier backups; it carries no meaning.
+MARK_PRUNED_SET_SQL = (
+    "lifecycle_state = 'stale', "
+    "metadata = json_set(COALESCE(metadata, '{}'), "
+    "    '$.pruned_reason', ?, "
+    "    '$._prev_status', COALESCE(json_extract(metadata, '$._status'), 'active'), "
+    "    '$._status', 'expired')"
+)
+
+# Restores `_status` from the stash, then drops both bookkeeping keys.
+RESTORE_SET_SQL = (
+    "lifecycle_state = NULL, "
+    "metadata = json_remove("
+    "    json_set(COALESCE(metadata, '{}'), "
+    "        '$._status', COALESCE(json_extract(metadata, '$._prev_status'), 'active')), "
+    "    '$.pruned_reason', '$._prev_status')"
+)
+
+
+def make_stdout_safe() -> None:
+    """Stop unencodable characters in previewed content from killing the run.
+
+    These scripts echo neuron content to stdout. On a Windows console defaulting
+    to cp1252 that raises UnicodeEncodeError on the first Vietnamese character —
+    which crashed a real run mid-brain, after committing some brains but not
+    others. Replacing the offending characters keeps the report readable and the
+    run atomic-ish; it does not touch what is written to the database.
+    """
+    stream = sys.stdout
+    if hasattr(stream, "reconfigure"):
+        stream.reconfigure(errors="replace")  # type: ignore[union-attr]
+
+
+def get_brain_base() -> Path:
+    """Resolve the brain storage directory from BRAIN_PATH or the default."""
+    env_path = os.environ.get("BRAIN_PATH", "")
+    if env_path:
+        return Path(env_path)
+    return Path.home() / ".neuralmemory"
+
+
+def find_brain_dbs() -> list[Path]:
+    """Find every brain database under the storage directory."""
+    candidates: list[Path] = []
+    base = get_brain_base()
+
+    main = base / "brain.db"
+    if main.exists():
+        candidates.append(main)
+
+    brains_dir = base / "brains"
+    if brains_dir.exists():
+        candidates.extend(sorted(brains_dir.glob("*.db")))
+
+    for f in sorted(base.glob("*.db")):
+        if f not in candidates:
+            candidates.append(f)
+
+    return candidates
+
+
+def has_neuron_columns(cur: sqlite3.Cursor, *columns: str) -> bool:
+    """True if a `neurons` table exists with all the given columns.
+
+    Older or alternate-schema brains are skipped rather than crashing the run.
+    """
+    cur.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='neurons'")
+    if cur.fetchone() is None:
+        return False
+    present = {r[1] for r in cur.execute("PRAGMA table_info(neurons)")}
+    return set(columns).issubset(present)
+
+
+def restore_by_reason(
+    cur: sqlite3.Cursor,
+    neuron_ids: list[str],
+    pruned_reason: str,
+) -> int:
+    """Un-hide neurons this script pruned. Returns the number restored.
+
+    Only rows still carrying ``pruned_reason`` are touched, so a row that some
+    other process has since modified is left alone.
+    """
+    if not neuron_ids:
+        return 0
+
+    restorable = []
+    for nid in neuron_ids:
+        cur.execute(
+            "SELECT json_extract(metadata, '$.pruned_reason') FROM neurons WHERE id = ?",
+            (nid,),
+        )
+        row = cur.fetchone()
+        if row and row[0] == pruned_reason:
+            restorable.append(nid)
+
+    if not restorable:
+        return 0
+
+    placeholders = ",".join("?" for _ in restorable)
+    cur.execute(
+        f"UPDATE neurons SET {RESTORE_SET_SQL} WHERE id IN ({placeholders})",  # noqa: S608 — static SET fragment, '?' params
+        restorable,
+    )
+    return cur.rowcount

--- a/scripts/prune-noisy-concepts.py
+++ b/scripts/prune-noisy-concepts.py
@@ -6,9 +6,15 @@ time, but existing noisy neurons remain in the database and surface during recal
 This script:
   1. Expands the noise set to cover common single-word code identifiers and
      generic nouns that carry zero topical signal.
-  2. Marks matching neurons as stale (lifecycle_state = 'stale') so the recall
-     pipeline naturally skips them.
+  2. Sets metadata._status = 'expired' so the recall pipeline skips them. That
+     is the ONLY marker retrieval reads — see scripts/_prune_status.py for why
+     the lifecycle_state column does not work for this (issue #195). The prior
+     status is stashed in metadata._prev_status so --unprune restores exactly.
   3. Reports what was cleaned so we can assess if more filtering is needed.
+
+Nothing is deleted. Re-running also repairs rows that an earlier version of
+this script marked 'stale' without setting _status — those were left fully
+recallable.
 
 Usage:
   python scripts/prune-noisy-concepts.py           # dry-run (default)
@@ -22,10 +28,20 @@ Supports BRAIN_PATH env var to override ~/.neuralmemory base directory.
 from __future__ import annotations
 
 import json
-import os
 import sqlite3
 import sys
 from pathlib import Path
+
+from _prune_status import (
+    MARK_PRUNED_SET_SQL,
+    STILL_VISIBLE_SQL,
+    find_brain_dbs,
+    has_neuron_columns,
+    make_stdout_safe,
+    restore_by_reason,
+)
+
+PRUNED_REASON = "noisy_low_signal"
 
 # ── Noise patterns ──────────────────────────────────────────
 # Short generic words that leak through entity extraction and
@@ -403,37 +419,6 @@ CODE_NOISE: set[str] = {
 # ── Helpers ─────────────────────────────────────────────────
 
 
-def _get_brain_base() -> Path:
-    """Resolve brain storage directory from env var or default."""
-    env_path = os.environ.get("BRAIN_PATH", "")
-    if env_path:
-        return Path(env_path)
-    return Path.home() / ".neuralmemory"
-
-
-def find_brain_dbs() -> list[Path]:
-    """Find all brain databases in the neural-memory directory."""
-    candidates: list[Path] = []
-    base = _get_brain_base()
-
-    # Main brain
-    main = base / "brain.db"
-    if main.exists():
-        candidates.append(main)
-
-    # Named brains
-    brains_dir = base / "brains"
-    if brains_dir.exists():
-        candidates.extend(brains_dir.glob("*.db"))
-
-    # Also check for any .db files directly in the base dir (alternate layouts)
-    for f in base.glob("*.db"):
-        if f not in candidates:
-            candidates.append(f)
-
-    return candidates
-
-
 def _noise_placeholders() -> tuple[set[str], str]:
     """Build placeholder string for SQL IN clause from noise sets."""
     noise_lower = {w.lower() for w in SHORT_NOISE | CODE_NOISE}
@@ -448,7 +433,7 @@ def count_noisy_neurons(cur: sqlite3.Cursor) -> int:
         "SELECT COUNT(*) FROM neurons "
         "WHERE type IN ('concept', 'entity') "
         f"AND LOWER(content) IN ({placeholders}) "
-        "AND (lifecycle_state IS NULL OR lifecycle_state != 'stale')"
+        f"AND {STILL_VISIBLE_SQL}"
     )
     cur.execute(sql, list(noise_lower))
     result = cur.fetchone()
@@ -464,24 +449,21 @@ def prune_noisy_neurons(cur: sqlite3.Cursor, dry_run: bool = True) -> int:
             "SELECT COUNT(*) FROM neurons "
             "WHERE type IN ('concept', 'entity') "
             f"AND LOWER(content) IN ({placeholders}) "
-            "AND (lifecycle_state IS NULL OR lifecycle_state != 'stale')"
+            f"AND {STILL_VISIBLE_SQL}"
         )
         cur.execute(dry_sql, list(noise_lower))
         result = cur.fetchone()
         return result[0] if result else 0
 
-    empty_obj = "'{}'"
-    json_val = "'" + '"noisy_low_signal"' + "'"
+    # S608 is ignored file-wide in pyproject: every interpolated fragment here
+    # is a static constant or a '?'-placeholder string, never user input.
     update_sql = (
-        "UPDATE neurons "
-        "SET lifecycle_state = 'stale', "
-        f"metadata = json_set(COALESCE(metadata, {empty_obj}), "
-        f"'$.pruned_reason', {json_val}) "
+        f"UPDATE neurons SET {MARK_PRUNED_SET_SQL} "
         "WHERE type IN ('concept', 'entity') "
         f"AND LOWER(content) IN ({placeholders}) "
-        "AND (lifecycle_state IS NULL OR lifecycle_state != 'stale')"
+        f"AND {STILL_VISIBLE_SQL}"
     )
-    cur.execute(update_sql, list(noise_lower))
+    cur.execute(update_sql, [PRUNED_REASON, *noise_lower])
     return cur.rowcount
 
 
@@ -493,7 +475,7 @@ def report_noise_sample(cur: sqlite3.Cursor, limit: int = 15) -> list[tuple]:
         "FROM neurons "
         "WHERE type IN ('concept', 'entity') "
         f"AND LOWER(content) IN ({placeholders}) "
-        "AND (lifecycle_state IS NULL OR lifecycle_state != 'stale') "
+        f"AND {STILL_VISIBLE_SQL} "
         "GROUP BY type, content "
         "ORDER BY cnt DESC "
         f"LIMIT {limit}"
@@ -511,8 +493,7 @@ def dump_affected_neurons(dbs: list[Path]) -> list[dict]:
     for db_path in dbs:
         conn = sqlite3.connect(str(db_path))
         cur = conn.cursor()
-        cur.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='neurons'")
-        if not cur.fetchone():
+        if not has_neuron_columns(cur, "content", "type", "metadata"):
             conn.close()
             continue
 
@@ -522,7 +503,7 @@ def dump_affected_neurons(dbs: list[Path]) -> list[dict]:
             FROM neurons
             WHERE type IN ('concept', 'entity')
             AND LOWER(content) IN ({placeholders})
-            AND (lifecycle_state IS NULL OR lifecycle_state != 'stale')
+            AND {STILL_VISIBLE_SQL}
             """,
             list(noise_lower),
         )
@@ -560,30 +541,20 @@ def unprune_neurons(dump_path: str) -> int:
     for brain_path, brain_records in brains.items():
         conn = sqlite3.connect(brain_path)
         cur = conn.cursor()
-        restorable = []
-        for r in brain_records:
-            nid = r["neuron_id"]
-            cur.execute("SELECT lifecycle_state FROM neurons WHERE id = ?", (nid,))
-            row = cur.fetchone()
-            if row and row[0] == "stale":
-                restorable.append(nid)
-
-        if restorable:
-            placeholders = ",".join("?" for _ in restorable)
-            cur.execute(
-                f"""
-                UPDATE neurons
-                SET lifecycle_state = NULL,
-                    metadata = json_remove(COALESCE(metadata, '{{}}'), '$.pruned_reason')
-                WHERE id IN ({placeholders})
-                """,
-                restorable,
-            )
+        # Restore only rows still carrying this script's marker — matching on
+        # lifecycle_state would both miss rows consolidation has since
+        # recomputed and wrongly claim rows another process marked stale.
+        restored = restore_by_reason(
+            cur,
+            [r["neuron_id"] for r in brain_records],
+            PRUNED_REASON,
+        )
+        if restored:
             conn.commit()
-            total_restored += cur.rowcount
-            print(f"  Restored {cur.rowcount} neurons in {Path(brain_path).name}")
+            total_restored += restored
+            print(f"  Restored {restored} neurons in {Path(brain_path).name}")
         else:
-            print(f"  No stale neurons to restore in {Path(brain_path).name}")
+            print(f"  Nothing pruned by this script to restore in {Path(brain_path).name}")
         conn.close()
 
     return total_restored
@@ -594,6 +565,7 @@ def unprune_neurons(dump_path: str) -> int:
 
 def main() -> None:
     """Run the prune, showing report with optional --execute to apply."""
+    make_stdout_safe()
     args = set(sys.argv[1:])
     dry_run = "--execute" not in args
     do_dump = "--dump" in args
@@ -606,7 +578,11 @@ def main() -> None:
             dump_path = sys.argv[i + 1]
 
     # Unprune mode
-    if do_unprune and dump_path:
+    if do_unprune:
+        if not dump_path:
+            print("Error: --unprune requires a dump file path")
+            print(f"  Usage: python {sys.argv[0]} --unprune prune-dump.json")
+            sys.exit(1)
         print("=" * 60)
         print("  NeuralMemory -- Unprune Mode")
         print(f"  Dump file: {dump_path}")
@@ -627,6 +603,11 @@ def main() -> None:
     if do_dump:
         affected = dump_affected_neurons(dbs)
         dump_file = Path("prune-dump.json")
+        if not affected:
+            # Never clobber an existing rollback backup with an empty list
+            # (e.g. running --dump again after --execute finds nothing left).
+            print(f"\nNo still-visible noisy neurons found; {dump_file} not written")
+            return
         with open(dump_file, "w") as f:
             json.dump(affected, f, indent=2)
         print(f"\nDumped {len(affected)} affected neuron(s) to {dump_file}")

--- a/scripts/prune-session-dumps.py
+++ b/scripts/prune-session-dumps.py
@@ -13,18 +13,23 @@ transcripts" memory-quality rule, dominate recall's "Related Information" surfac
 inflate the neuron count, and drag down the brain's freshness/purity grade. A real
 audit (my-brain.v2) found 428 such neurons active in a single brain.
 
-Same safe, reversible mechanism as the concept pruner:
-  1. Match neurons whose content starts with the literal ``[SESSION]`` marker.
-     (In SQLite ``LIKE`` the brackets are literal — only ``%``/``_`` are wildcards —
-     so ``content LIKE '[SESSION]%'`` matches exactly that prefix.)
-  2. Mark matches with BOTH exclusion markers:
-       - ``metadata._status = 'expired'`` — the marker retrieval actually gates on:
-         ``_filter_by_status`` default-allows only ``active`` (NeuronStatus contract,
-         see ``core/neuron.py``), so this is what removes dumps from recall.
-       - ``lifecycle_state = 'stale'`` — bookkeeping column used by this script's
-         own idempotence check, consistent with ``prune-noisy-concepts.py``.
-     The original ``_status`` is preserved in ``metadata._prev_status`` so
-     ``--unprune`` restores it faithfully. Nothing is deleted.
+Dump text reaches recall through THREE independent surfaces, and all three
+have to be cleared — clearing fewer leaves the transcript readable:
+
+  1. ``neurons.content`` — matched on the session-flush signatures in
+     ``SESSION_PATTERNS``, anywhere in the text rather than only as a prefix.
+     Matches are marked with ``metadata._status = 'expired'``, which is the
+     marker retrieval actually gates on (``_filter_by_status`` default-allows
+     only ``active``). ``lifecycle_state`` is written too but means nothing —
+     see ``scripts/_prune_status.py``. The prior ``_status`` is stashed in
+     ``metadata._prev_status`` so ``--unprune`` restores it faithfully.
+  2. ``fibers.summary`` — read directly by the fiber-summary retrieval tier,
+     which consults only the fiber's *anchor* neuron for status. A dump fiber
+     anchored on an ordinary concept therefore leaks regardless of step 1.
+  3. ``fibers.essence`` — a second, separate text field on the same row.
+
+Nothing is deleted: neurons are hidden, fiber text is blanked, and both are
+saved to the JSON backup for ``--unprune``.
 
 Usage:
   python scripts/prune-session-dumps.py            # dry-run (default)
@@ -38,116 +43,114 @@ Supports BRAIN_PATH env var to override the ~/.neuralmemory base directory.
 from __future__ import annotations
 
 import json
-import os
 import sqlite3
 import sys
 from pathlib import Path
 
-# ── Match pattern ───────────────────────────────────────────
-# Neurons whose content begins with this literal marker are session-transcript
-# dumps. LIKE treats the brackets literally (only % and _ are wildcards), so this
-# is an exact prefix match, not a character class.
-SESSION_PREFIX = "[SESSION]%"
+from _prune_status import (
+    MARK_PRUNED_SET_SQL,
+    STILL_VISIBLE_SQL,
+    find_brain_dbs,
+    has_neuron_columns,
+    make_stdout_safe,
+    restore_by_reason,
+)
+
 BACKUP_FILE = "prune-session-dump.json"
 PRUNED_REASON = "session_transcript_dump"
+
+# ── Match patterns ──────────────────────────────────────────
+# Signatures of the session-flush template. LIKE treats the brackets literally
+# (only % and _ are wildcards), so "[SESSION]" is matched as text.
+#
+# Matching the marker ANYWHERE, not just as a prefix, is deliberate: concept
+# extraction re-emitted fragments of these transcripts as their own neurons,
+# and those start with things like "Duration = 74s" or "User", so a prefix rule
+# missed them entirely.
+#
+# Length is NOT part of the signature, and must not be: the longest neurons in
+# a real brain turned out to be imported Vietnamese legal texts and company tax
+# records. A size threshold would have destroyed them. These three markers hit
+# 50 dump fragments and 0 of those documents.
+SESSION_PATTERNS = (
+    "%[SESSION]%",
+    "%Key exchanges:%",
+    "%SESSION END%",
+)
+
+_CONTENT_MATCH = " OR ".join("content LIKE ?" for _ in SESSION_PATTERNS)
 
 # A dump still surfaces in recall unless metadata._status hides it — that is the
 # only marker retrieval reads. Match on that (NOT on lifecycle_state) so re-running
 # the script also repairs rows an older version marked 'stale' without setting
 # _status (they were still fully recallable).
-NEEDS_PRUNE_WHERE = (
-    "content LIKE ? "
-    "AND COALESCE(json_extract(metadata, '$._status'), 'active') NOT IN ('expired', 'superseded')"
-)
+NEEDS_PRUNE_WHERE = f"({_CONTENT_MATCH}) AND {STILL_VISIBLE_SQL}"
 
 # ── Helpers ─────────────────────────────────────────────────
 
 
-def _get_brain_base() -> Path:
-    """Resolve brain storage directory from env var or default."""
-    env_path = os.environ.get("BRAIN_PATH", "")
-    if env_path:
-        return Path(env_path)
-    return Path.home() / ".neuralmemory"
-
-
-def find_brain_dbs() -> list[Path]:
-    """Find all brain databases in the neural-memory directory."""
-    candidates: list[Path] = []
-    base = _get_brain_base()
-
-    main = base / "brain.db"
-    if main.exists():
-        candidates.append(main)
-
-    brains_dir = base / "brains"
-    if brains_dir.exists():
-        candidates.extend(sorted(brains_dir.glob("*.db")))
-
-    for f in sorted(base.glob("*.db")):
-        if f not in candidates:
-            candidates.append(f)
-
-    return candidates
-
-
-def _prunable(cur: sqlite3.Cursor) -> bool:
-    """True only if this DB has a `neurons` table with the columns we touch —
-    older/alternate-schema brains may lack `content`/`lifecycle_state`; skip them
-    rather than crash."""
-    cur.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='neurons'")
-    if cur.fetchone() is None:
-        return False
-    cols = {r[1] for r in cur.execute("PRAGMA table_info(neurons)")}
-    return {"content", "lifecycle_state"}.issubset(cols)
-
-
 def _fibers_prunable(cur: sqlite3.Cursor) -> bool:
-    """True if this DB has a `fibers` table with a `summary` column."""
+    """True if this DB has a `fibers` table with both text columns we clear."""
     cur.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='fibers'")
     if cur.fetchone() is None:
         return False
     cols = {r[1] for r in cur.execute("PRAGMA table_info(fibers)")}
-    return "summary" in cols
+    return {"summary", "essence"}.issubset(cols)
+
+
+# Fibers carry the dump text in TWO columns and both reach recall independently.
+_FIBER_MATCH = {
+    col: " OR ".join(f"{col} LIKE ?" for _ in SESSION_PATTERNS) for col in ("summary", "essence")
+}
 
 
 def count_dump_fibers(cur: sqlite3.Cursor) -> int:
-    """Count fibers whose own summary is a session dump.
+    """Count fibers carrying session-dump text in `summary` or `essence`.
 
-    Neuron-level pruning does not cover these: the fiber-summary retrieval tier
+    Neuron-level pruning does not cover these. The fiber-summary retrieval tier
     reads ``fibers.summary`` directly, and ``_filter_fibers_by_status`` only
-    consults the *anchor* neuron. A dump fiber anchored on an ordinary concept
-    neuron therefore keeps leaking the transcript into recall.
+    consults the *anchor* neuron, so a dump fiber anchored on an ordinary
+    concept neuron keeps leaking the transcript. ``essence`` is a second,
+    separate surface — blanking only the summary leaves the dump readable
+    through the essence field, which is exactly what happened the first time.
     """
     cur.execute(
-        "SELECT COUNT(*) FROM fibers WHERE summary LIKE ?",
-        (SESSION_PREFIX,),
+        f"SELECT COUNT(*) FROM fibers WHERE ({_FIBER_MATCH['summary']}) "  # noqa: S608 — static fragments, '?' params
+        f"OR ({_FIBER_MATCH['essence']})",
+        (*SESSION_PATTERNS, *SESSION_PATTERNS),
     )
     result = cur.fetchone()
     return result[0] if result else 0
 
 
-def prune_fibers(cur: sqlite3.Cursor) -> int:
-    """Blank session-dump fiber summaries. Returns affected row count.
+def prune_fibers(cur: sqlite3.Cursor) -> tuple[int, int]:
+    """Blank dump text from fiber `summary` and `essence`.
 
-    The fiber itself is kept (it still links real neurons); only the polluted
-    summary text is cleared. Retrieval skips fibers with an empty summary
+    Returns ``(summaries_blanked, essences_blanked)``.
+
+    The fiber itself is kept — it still links real neurons; only the polluted
+    text goes. Retrieval skips fibers with an empty summary
     (``_try_fiber_summary_tier``: ``if not summary: continue``), and the
     ``fibers_au`` trigger keeps the ``fibers_fts`` index in sync automatically.
-    Original summaries go to the JSON backup for ``--unprune``.
+    Originals go to the JSON backup for ``--unprune``.
     """
     cur.execute(
-        "UPDATE fibers SET summary = NULL WHERE summary LIKE ?",
-        (SESSION_PREFIX,),
+        f"UPDATE fibers SET summary = NULL WHERE {_FIBER_MATCH['summary']}",  # noqa: S608 — static fragment, '?' params
+        SESSION_PATTERNS,
     )
-    return cur.rowcount
+    summaries = cur.rowcount
+    cur.execute(
+        f"UPDATE fibers SET essence = NULL WHERE {_FIBER_MATCH['essence']}",  # noqa: S608 — static fragment, '?' params
+        SESSION_PATTERNS,
+    )
+    return summaries, cur.rowcount
 
 
 def count_session_dumps(cur: sqlite3.Cursor) -> int:
     """Count session-dump neurons still visible to recall."""
     cur.execute(
         f"SELECT COUNT(*) FROM neurons WHERE {NEEDS_PRUNE_WHERE}",  # noqa: S608 — static WHERE fragment, '?' params
-        (SESSION_PREFIX,),
+        SESSION_PATTERNS,
     )
     result = cur.fetchone()
     return result[0] if result else 0
@@ -158,7 +161,7 @@ def report_sample(cur: sqlite3.Cursor, limit: int = 8) -> list[tuple]:
     cur.execute(
         "SELECT type, substr(replace(content, char(10), ' '), 1, 70) AS preview "  # noqa: S608 — static WHERE fragment; LIMIT is an internal int
         f"FROM neurons WHERE {NEEDS_PRUNE_WHERE} LIMIT {int(limit)}",
-        (SESSION_PREFIX,),
+        SESSION_PATTERNS,
     )
     return cur.fetchall()
 
@@ -174,10 +177,10 @@ def dump_affected(dbs: list[Path]) -> list[dict]:
     for db_path in dbs:
         conn = sqlite3.connect(str(db_path))
         cur = conn.cursor()
-        if _prunable(cur):
+        if has_neuron_columns(cur, "content", "metadata"):
             cur.execute(
                 f"SELECT id, type, content, lifecycle_state FROM neurons WHERE {NEEDS_PRUNE_WHERE}",  # noqa: S608 — static WHERE fragment, '?' params
-                (SESSION_PREFIX,),
+                SESSION_PATTERNS,
             )
             for row in cur.fetchall():
                 affected.append(
@@ -192,8 +195,9 @@ def dump_affected(dbs: list[Path]) -> list[dict]:
                 )
         if _fibers_prunable(cur):
             cur.execute(
-                "SELECT id, summary FROM fibers WHERE summary LIKE ?",
-                (SESSION_PREFIX,),
+                f"SELECT id, summary, essence FROM fibers "  # noqa: S608 — static fragments, '?' params
+                f"WHERE ({_FIBER_MATCH['summary']}) OR ({_FIBER_MATCH['essence']})",
+                (*SESSION_PATTERNS, *SESSION_PATTERNS),
             )
             for row in cur.fetchall():
                 affected.append(
@@ -202,6 +206,7 @@ def dump_affected(dbs: list[Path]) -> list[dict]:
                         "brain": str(db_path),
                         "fiber_id": row[0],
                         "summary": row[1],
+                        "essence": row[2],
                     }
                 )
         conn.close()
@@ -217,14 +222,8 @@ def prune(cur: sqlite3.Cursor) -> int:
     ``metadata._prev_status`` so unprune can restore it exactly.
     """
     cur.execute(
-        "UPDATE neurons "  # noqa: S608 — static WHERE fragment, '?' params
-        "SET lifecycle_state = 'stale', "
-        "metadata = json_set(COALESCE(metadata, '{}'), "
-        "    '$.pruned_reason', ?, "
-        "    '$._prev_status', COALESCE(json_extract(metadata, '$._status'), 'active'), "
-        "    '$._status', 'expired') "
-        f"WHERE {NEEDS_PRUNE_WHERE}",
-        (PRUNED_REASON, SESSION_PREFIX),
+        f"UPDATE neurons SET {MARK_PRUNED_SET_SQL} WHERE {NEEDS_PRUNE_WHERE}",  # noqa: S608 — static fragments, '?' params
+        (PRUNED_REASON, *SESSION_PATTERNS),
     )
     return cur.rowcount
 
@@ -252,48 +251,34 @@ def unprune(dump_path: str) -> int:
         for r in brain_records:
             if r.get("kind") != "fiber":
                 continue
+            # Restore each column only where it is still blank, so text
+            # rewritten since the backup is never clobbered. Backups predating
+            # essence support simply have no "essence" key.
             cur.execute(
                 "UPDATE fibers SET summary = ? WHERE id = ? AND summary IS NULL",
                 (r["summary"], r["fiber_id"]),
             )
             fiber_restored += cur.rowcount
+            if r.get("essence") is not None:
+                cur.execute(
+                    "UPDATE fibers SET essence = ? WHERE id = ? AND essence IS NULL",
+                    (r["essence"], r["fiber_id"]),
+                )
+                fiber_restored += cur.rowcount
         if fiber_restored:
             conn.commit()
             total += fiber_restored
             print(f"  Restored {fiber_restored} fiber summaries in {Path(brain_path).name}")
 
-        restorable = []
-        for r in brain_records:
-            # Records without `kind` come from a pre-fiber-support backup — neurons.
-            if r.get("kind", "neuron") != "neuron":
-                continue
-            # Restore only rows this script pruned (identified by its own marker),
-            # not rows some other process happened to mark stale.
-            cur.execute(
-                "SELECT json_extract(metadata, '$.pruned_reason') FROM neurons WHERE id = ?",
-                (r["neuron_id"],),
-            )
-            row = cur.fetchone()
-            if row and row[0] == PRUNED_REASON:
-                restorable.append(r["neuron_id"])
-        if restorable:
-            placeholders = ",".join("?" for _ in restorable)
-            # Restore _status from the stashed _prev_status (default 'active'),
-            # then drop the bookkeeping keys this script added.
-            cur.execute(
-                "UPDATE neurons SET lifecycle_state = NULL, "  # noqa: S608 — interpolation is '?' placeholders only
-                "metadata = json_remove("
-                "    json_set(COALESCE(metadata, '{}'), "
-                "        '$._status', COALESCE(json_extract(metadata, '$._prev_status'), 'active')), "
-                "    '$.pruned_reason', '$._prev_status') "
-                f"WHERE id IN ({placeholders})",
-                restorable,
-            )
+        # Records without `kind` come from a pre-fiber-support backup — neurons.
+        neuron_ids = [r["neuron_id"] for r in brain_records if r.get("kind", "neuron") == "neuron"]
+        restored = restore_by_reason(cur, neuron_ids, PRUNED_REASON)
+        if restored:
             conn.commit()
-            total += cur.rowcount
-            print(f"  Restored {cur.rowcount} neurons in {Path(brain_path).name}")
+            total += restored
+            print(f"  Restored {restored} neurons in {Path(brain_path).name}")
         else:
-            print(f"  No stale neurons to restore in {Path(brain_path).name}")
+            print(f"  Nothing pruned by this script to restore in {Path(brain_path).name}")
         conn.close()
     return total
 
@@ -302,6 +287,7 @@ def unprune(dump_path: str) -> int:
 
 
 def main() -> None:
+    make_stdout_safe()
     args = set(sys.argv[1:])
     dry_run = "--execute" not in args
     do_dump = "--dump" in args
@@ -355,7 +341,7 @@ def main() -> None:
         name = db_path.name
         conn = sqlite3.connect(str(db_path))
         cur = conn.cursor()
-        has_neurons = _prunable(cur)
+        has_neurons = has_neuron_columns(cur, "content", "metadata")
         has_fibers = _fibers_prunable(cur)
         if not has_neurons and not has_fibers:
             conn.close()
@@ -369,7 +355,7 @@ def main() -> None:
             conn.close()
             continue
 
-        print(f"\n  [{name}] {found} session-dump neuron(s), {found_fibers} dump fiber summaries")
+        print(f"\n  [{name}] {found} session-dump neuron(s), {found_fibers} dump fiber(s)")
         if found:
             for typ, preview in report_sample(cur):
                 print(f'      {typ:8s} "{preview}"')
@@ -377,16 +363,16 @@ def main() -> None:
         if not dry_run:
             all_affected.extend(dump_affected([db_path]))
             pruned = prune(cur) if has_neurons else 0
-            pruned_fibers = prune_fibers(cur) if has_fibers else 0
+            blanked_sum, blanked_ess = prune_fibers(cur) if has_fibers else (0, 0)
             conn.commit()
             total_pruned += pruned
-            total_fibers_pruned += pruned_fibers
-            print(f"    -> Pruned {pruned} neuron(s), blanked {pruned_fibers} fiber summaries")
-        else:
+            total_fibers_pruned += blanked_sum + blanked_ess
             print(
-                f"    -> Would prune {found} neuron(s) + "
-                f"{found_fibers} fiber summaries (use --execute)"
+                f"    -> Pruned {pruned} neuron(s), blanked "
+                f"{blanked_sum} summaries + {blanked_ess} essences"
             )
+        else:
+            print(f"    -> Would prune {found} neuron(s) + {found_fibers} fiber(s) (use --execute)")
         conn.close()
 
     if not dry_run and all_affected:
@@ -398,13 +384,13 @@ def main() -> None:
     if dry_run:
         print(
             f"  Total: {total_found} session-dump neuron(s) + "
-            f"{total_fibers} dump fiber summaries across {len(dbs)} DB(s)"
+            f"{total_fibers} dump fiber(s) across {len(dbs)} DB(s)"
         )
         print("  Run with --execute to apply (writes a rollback backup)")
     else:
         print(
             f"  Pruned: {total_pruned} session-dump neuron(s), "
-            f"blanked {total_fibers_pruned} fiber summaries"
+            f"blanked {total_fibers_pruned} fiber text field(s)"
         )
     print(f"{'=' * 60}")
 

--- a/src/neural_memory/storage/postgres/postgres_schema.py
+++ b/src/neural_memory/storage/postgres/postgres_schema.py
@@ -49,6 +49,8 @@ _INIT_SQL_TEMPLATE = [
         updated_at TEXT DEFAULT '',
         created_at TIMESTAMPTZ NOT NULL,
         last_accessed_at TIMESTAMPTZ,
+        -- DERIVED, consolidation-owned; recomputed from heat + age on every
+        -- `lifecycle` run. NOT a recall gate — retrieval reads metadata._status.
         lifecycle_state TEXT DEFAULT 'active',
         frozen INTEGER DEFAULT 0,
         ephemeral INTEGER DEFAULT 0,

--- a/src/neural_memory/storage/sqlite_schema.py
+++ b/src/neural_memory/storage/sqlite_schema.py
@@ -772,6 +772,10 @@ CREATE TABLE IF NOT EXISTS neurons (
     updated_at TEXT DEFAULT '',  -- Last modification timestamp
     created_at TEXT NOT NULL,
     last_accessed_at TEXT,  -- Updated on every recall hit (batch)
+    -- DERIVED, consolidation-owned. Recomputed from heat + age for every neuron
+    -- on each `lifecycle` consolidation run, so any value written here is
+    -- overwritten. NOT a recall gate: no retrieval path reads this column.
+    -- To hide a neuron from recall set metadata._status (see NeuronStatus).
     lifecycle_state TEXT DEFAULT 'active',  -- ACTIVE | WARM | COOL | COMPRESSED | ARCHIVED
     frozen INTEGER DEFAULT 0,  -- 1 = never compress
     ephemeral INTEGER DEFAULT 0,  -- 1 = session-scoped, auto-expires, never synced


### PR DESCRIPTION
Closes #195.

## The reported bug
`prune-noisy-concepts.py` had the same flaw #191 had: it wrote only `lifecycle_state`, so every concept it "pruned" stayed fully recallable. Worse, that column is **derived** — the `lifecycle` consolidation strategy recomputes it from heat and age for every neuron on each run — so the marker was also being erased over time.

Both facts now live in one place, `scripts/_prune_status.py`. The bug existed twice for exactly one reason: the logic was copied.

## Two more leaks, found by verifying instead of assuming
I ran the fix on the live brain and then re-ran a real `nmem_recall` — the transcript junk was **still there**. Two surfaces I had missed:

- **`fibers.essence`.** PR #196 blanked `summary`, but essence is a separate text field on the same row. 455 fibers still carried the full transcript there.
- **Neurons containing a dump signature but not starting with one.** Concept extraction re-emitted transcript fragments as their own neurons beginning `"Duration = 74s"` or `"User"`, so the `[SESSION]%` prefix rule never saw them.

Matching is now by signature **anywhere** in the text (`[SESSION]`, `Key exchanges:`, `SESSION END`), and fiber pruning clears both columns.

## What I deliberately did NOT do
Use length as a signal. The longest neurons in the real brain turned out to be **imported Vietnamese legal texts** (18k chars — Luật An ninh mạng 2018, Luật ATVSLĐ 2015) and **company tax records**. A size threshold would have destroyed them. Verified the three markers hit 50 dump fragments and **0** of those documents.

## A crash this surfaced
The scripts echo neuron content to stdout, which raised `UnicodeEncodeError` on the first Vietnamese character under a cp1252 Windows console — aborting a real run *after* it had already committed some brains. `make_stdout_safe()` fixes it.

## Also
- `--unprune` without a path now errors instead of falling through to the prune flow; `--dump` refuses to clobber an existing rollback backup with an empty list (carried over to the concept pruner).
- `lifecycle_state` documented as derived and consolidation-owned in both the SQLite and Postgres schemas, so it is not mistaken for a gate again.

## Verification
- Both smoke tests pass, including a case asserting a long legitimate document survives pruning and one asserting a mid-text signature is caught.
- Applied to the live brain: 50 neurons + 474 fiber text fields. A real `nmem_recall` now returns **no transcript text at all** — previously the top hit was a wall of session dump.
- 101 storage tests pass; schema DDL still valid; ruff clean.
