### PR TITLE
docs: fix the landing page's a11y + brand + wrong numbers, surface the site in the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,8 +216,8 @@ Pro  (HNSW):  7 results — includes "JWT rotation", "session hardening", "OAuth
 
 ```bash
 pip install neural-memory                 # Pro features included
-nmem pro activate YOUR_LICENSE_KEY       # activate license
-nmem pro status                          # verify: Pro: Active
+nmem shared activate --key NM-PRO-XXXX-XXXX-XXXX   # activate license
+nmem shared status                                 # verify: Pro: Active
 ```
 
 **[$9/mo](https://neuralmemory.theio.vn/landing/pricing/)** — 30-day money-back guarantee. All free tools keep working. Downgrade anytime, keep your data.
@@ -277,7 +277,7 @@ Set memory slot in `~/.openclaw/openclaw.json`:
 Already using Neural Memory? Just activate your key:
 
 ```bash
-nmem pro activate YOUR_LICENSE_KEY    # activate license
+nmem shared activate --key NM-PRO-XXXX-XXXX-XXXX   # activate license
 ```
 
 Then enable InfinityDB (semantic search engine):

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@
 **Your AI agent forgets everything between sessions. Neural Memory gives it a brain.**
 
 <p align="center">
+  <strong><a href="https://neuralmemory.theio.vn">Website</a></strong> ·
+  <a href="https://neuralmemory.theio.vn/guides/quickstart-guide/">Quickstart</a> ·
+  <a href="https://neuralmemory.theio.vn/api/mcp-tools/">MCP Tools</a> ·
+  <a href="https://neuralmemory.theio.vn/landing/pro-landing.html">Pro</a> ·
+  <a href="https://neuralmemory.theio.vn/changelog/">Changelog</a>
+</p>
+
+<p align="center">
   <img src="docs/assets/images/hero-brain.svg" alt="Neural Memory — spreading activation" width="720"/>
 </p>
 
@@ -22,6 +30,10 @@ pip install neural-memory
 ```
 
 Restart your AI tool. Your agent now remembers — no `init` needed, the MCP server auto-initializes on first use.
+
+**Already installed?** `nmem update` upgrades in place and detects whether you installed via pip or from source. `nmem update --check` only reports what is available.
+
+> The CLI is `nmem` (or the longer `neural-memory`). There is no `nm` binary.
 
 ---
 
@@ -37,7 +49,7 @@ Restart your AI tool. Your agent now remembers — no `init` needed, the MCP ser
 
 Everything else — sessions, context loading, habit tracking, maintenance — works transparently in the background.
 
-> [All 63 MCP tools →](https://nhadaututtheky.github.io/neural-memory/api/mcp-tools/)
+> [All 63 MCP tools →](https://neuralmemory.theio.vn/api/mcp-tools/)
 
 ---
 
@@ -83,7 +95,7 @@ nmem sync --auto       # auto-sync after every remember/recall
 
 Sync uses **Merkle delta** — only diffs travel, not the full brain. Fast, efficient, private.
 
-> [Cloud Sync setup guide →](https://nhadaututtheky.github.io/neural-memory/guides/cloud-sync/)
+> [Cloud Sync setup guide →](https://neuralmemory.theio.vn/guides/cloud-sync/)
 
 ---
 
@@ -94,7 +106,7 @@ Sync uses **Merkle delta** — only diffs travel, not the full brain. Fast, effi
 - **Spreading activation** — memories surface by association, not keyword match
 - **Cognitive reasoning** — hypothesize, submit evidence, make predictions, verify with Bayesian confidence
 - **Workload presets** — `nmem config preset {balanced,safe-cost,max-recall,chat-heavy}` tune the brain for SaaS, frugal mode, deep retention, or conversational agents
-- **Temporal recall** — `nmem_causal` exposes `temporal_range` and `temporal_neighborhood` actions; see the [Temporal Recall Recipes guide](https://nhadaututtheky.github.io/neural-memory/guides/temporal-recipes/)
+- **Temporal recall** — `nmem_causal` exposes `temporal_range` and `temporal_neighborhood` actions; see the [Temporal Recall Recipes guide](https://neuralmemory.theio.vn/guides/temporal-recipes/)
 
 #### Knowledge Ingestion
 - **Train from documents** — PDF, DOCX, PPTX, HTML, JSON, XLSX, CSV ingested into permanent brain knowledge
@@ -208,9 +220,9 @@ nmem pro activate YOUR_LICENSE_KEY       # activate license
 nmem pro status                          # verify: Pro: Active
 ```
 
-**[$9/mo](https://nhadaututtheky.github.io/neural-memory/landing/pricing/)** — 30-day money-back guarantee. All free tools keep working. Downgrade anytime, keep your data.
+**[$9/mo](https://neuralmemory.theio.vn/landing/pricing/)** — 30-day money-back guarantee. All free tools keep working. Downgrade anytime, keep your data.
 
-> [Pro quickstart →](https://nhadaututtheky.github.io/neural-memory/guides/pro-quickstart/) · [Full comparison →](https://nhadaututtheky.github.io/neural-memory/landing/pro/) · [Pricing →](https://nhadaututtheky.github.io/neural-memory/landing/pricing/)
+> [Pro quickstart →](https://neuralmemory.theio.vn/guides/pro-quickstart/) · [Full comparison →](https://neuralmemory.theio.vn/landing/pro/) · [Pricing →](https://neuralmemory.theio.vn/landing/pricing/)
 
 ---
 
@@ -277,7 +289,7 @@ storage_backend = "infinitydb"
 
 Restart your MCP server. Existing memories are auto-migrated from SQLite to InfinityDB on first startup.
 
-> [Get a license →](https://nhadaututtheky.github.io/neural-memory/landing/pricing/) · [Pro quickstart →](https://nhadaututtheky.github.io/neural-memory/guides/pro-quickstart/)
+> [Get a license →](https://neuralmemory.theio.vn/landing/pricing/) · [Pro quickstart →](https://neuralmemory.theio.vn/guides/pro-quickstart/)
 
 </details>
 
@@ -314,14 +326,14 @@ Zero LLM calls, zero API cost. [Full benchmarks →](docs/benchmarks.md)
 
 | Guide | Description |
 |-------|-------------|
-| [Quickstart Guide](https://nhadaututtheky.github.io/neural-memory/guides/quickstart-guide/) | Interactive guide with animated demos |
-| [Pro Quickstart](https://nhadaututtheky.github.io/neural-memory/guides/pro-quickstart/) | Get started with Pro features |
-| [CLI Reference](https://nhadaututtheky.github.io/neural-memory/getting-started/cli-reference/) | All 66 CLI commands |
-| [MCP Tools Reference](https://nhadaututtheky.github.io/neural-memory/api/mcp-tools/) | All 63 MCP tools with parameters |
-| [Cloud Sync](https://nhadaututtheky.github.io/neural-memory/guides/cloud-sync/) | Multi-device sync setup |
-| [Brain Health Guide](https://nhadaututtheky.github.io/neural-memory/guides/brain-health/) | Understanding and improving brain health |
-| [Embedding Setup](https://nhadaututtheky.github.io/neural-memory/guides/embedding-setup/) | Configure embedding providers |
-| [Architecture](https://nhadaututtheky.github.io/neural-memory/architecture/overview/) | Technical design deep-dive |
+| [Quickstart Guide](https://neuralmemory.theio.vn/guides/quickstart-guide/) | Interactive guide with animated demos |
+| [Pro Quickstart](https://neuralmemory.theio.vn/guides/pro-quickstart/) | Get started with Pro features |
+| [CLI Reference](https://neuralmemory.theio.vn/getting-started/cli-reference/) | All 82 CLI commands |
+| [MCP Tools Reference](https://neuralmemory.theio.vn/api/mcp-tools/) | All 63 MCP tools with parameters |
+| [Cloud Sync](https://neuralmemory.theio.vn/guides/cloud-sync/) | Multi-device sync setup |
+| [Brain Health Guide](https://neuralmemory.theio.vn/guides/brain-health/) | Understanding and improving brain health |
+| [Embedding Setup](https://neuralmemory.theio.vn/guides/embedding-setup/) | Configure embedding providers |
+| [Architecture](https://neuralmemory.theio.vn/architecture/overview/) | Technical design deep-dive |
 
 ## Development
 

--- a/dashboard/e2e/landing.spec.ts
+++ b/dashboard/e2e/landing.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from "@playwright/test"
+import { fileURLToPath, pathToFileURL } from "node:url"
+import path from "node:path"
+
+// Resolved from this spec's location so the suite is not tied to one machine.
+// The project is ESM, so __dirname is unavailable — derive it from import.meta.
+const HERE = path.dirname(fileURLToPath(import.meta.url))
+const FILE = pathToFileURL(
+  path.resolve(HERE, "../../docs/landing/pro-landing.html"),
+).href
+
+test("landing: no console errors, scene boots, keyboard reaches every panel", async ({ page }) => {
+  const errs: string[] = []
+  page.on("pageerror", (e) => errs.push("PAGEERROR: " + e.message))
+  page.on("console", (m) => { if (m.type() === "error") errs.push(m.text()) })
+
+  await page.goto(FILE)
+  await page.waitForTimeout(3000)
+
+  // every feature must be reachable as a real button
+  const labels = page.locator("button.cluster-label")
+  expect(await labels.count()).toBe(6)
+
+  // keyboard: focus a cluster button and activate with Enter
+  await labels.nth(2).focus()
+  await expect(labels.nth(2)).toBeFocused()
+  await page.keyboard.press("Enter")
+  await expect(page.locator("#feature-panel")).toHaveClass(/open/)
+  const text = await page.locator("#panel-content").innerText()
+  expect(text.length).toBeGreaterThan(50)
+
+  console.log("CONSOLE ERRORS:", JSON.stringify(errs.slice(0, 5)))
+})
+
+test("landing: fallback appears when the three.js CDN is unreachable", async ({ page }) => {
+  await page.route("**/cdn.jsdelivr.net/**", (r) => r.abort())
+  await page.goto(FILE)
+  await page.waitForTimeout(5000)
+
+  const fb = page.locator("#scene-fallback")
+  await expect(fb).toBeVisible()
+  // and the buttons must actually open a panel without the 3D module
+  await fb.getByRole("button", { name: "Pricing" }).click()
+  await expect(page.locator("#feature-panel")).toHaveClass(/open/)
+  await expect(page.locator("#panel-content")).toContainText("$9")
+})
+
+test("landing: cluster labels stay inside a 375px viewport", async ({ page }) => {
+  // The page is a fixed-viewport app shell (body{overflow:hidden}) and the
+  // feature panel is parked off-screen by design, so documentElement
+  // scrollWidth is not the thing to assert. What is user-visible is whether the
+  // 3D-projected labels get clipped at the screen edge.
+  await page.setViewportSize({ width: 375, height: 700 })
+  await page.goto(FILE)
+  await page.waitForTimeout(3000)
+  const clipped = await page.evaluate(() => {
+    const vw = document.documentElement.clientWidth
+    return [...document.querySelectorAll("button.cluster-label")]
+      .map((el) => ({ id: el.id, r: el.getBoundingClientRect() }))
+      .filter(({ r }) => r.left < 0 || r.right > vw)
+      .map(({ id, r }) => `${id} left=${Math.round(r.left)} right=${Math.round(r.right)}`)
+  })
+  console.log("CLIPPED LABELS:", JSON.stringify(clipped))
+  expect(clipped).toEqual([])
+})

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@
 </p>
 
 <p align="center">
-  <a href="https://neuralmemory.theio.vn/landing/pro-landing.html" target="_blank"><img src="https://img.shields.io/badge/Neural_Memory_Pro-6366f1?style=for-the-badge&logo=lightning&logoColor=white" alt="Neural Memory Pro"></a>
+  <a href="https://neuralmemory.theio.vn/landing/pro-landing.html" target="_blank"><img src="https://img.shields.io/badge/Neural_Memory_Pro-0f766e?style=for-the-badge&logo=lightning&logoColor=white" alt="Neural Memory Pro"></a>
   <a href="https://buymeacoffee.com/vietnamit"><img src="https://img.shields.io/badge/Buy%20Me%20A%20Coffee-ffdd00?style=for-the-badge&logo=buy-me-a-coffee&logoColor=black" alt="Buy Me A Coffee"></a>
 </p>
 

--- a/docs/landing/pro-landing.html
+++ b/docs/landing/pro-landing.html
@@ -40,7 +40,19 @@
       --text: #e8e8f0;
       --text-muted: #8888aa;
       --border: #2a2a5a;
+      /* Brand — teal, matching the dashboard (--color-primary #0f766e/#2dd4bf).
+         --brand is used as TEXT so it must clear 4.5:1 on --bg-card and differs
+         per theme; --brand-solid is the button fill carrying white text
+         (5.47:1) and is shared. The previous brand was --violet #7c3aed, which
+         measured 3.33:1 on #0e0e24 and failed AA wherever it was text. */
+      --brand: #2dd4bf;
+      --brand-solid: #0f766e;
+      --brand-ink: #ffffff;
+      --danger: #f87171;
+      /* Categorical hues for the six feature clusters — deliberately separate
+         from --brand so a cluster color never reads as an interactive control. */
       --violet: #7c3aed;
+      --violet-text: #a78bfa;
       --cyan: #06b6d4;
       --pink: #f472b6;
       --amber: #fbbf24;
@@ -57,6 +69,9 @@
       --text: #1a1a2e;
       --text-muted: #6b6b8a;
       --border: #d4d4e0;
+      --brand: #0f766e;
+      --violet-text: #6d28d9;
+      --danger: #dc2626;
       --scene-bg: #e8e6e0;
       --panel-blur: 24px;
     }
@@ -91,6 +106,8 @@
       display: flex;
       align-items: center;
       justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;   /* never let the row push past the viewport */
       padding: 16px 24px;
       pointer-events: none;
     }
@@ -109,8 +126,8 @@
     .logo .pro-badge {
       font-family: 'JetBrains Mono', monospace;
       font-size: 10px;
-      background: rgba(124, 58, 237, 0.2);
-      color: var(--pulse);
+      background: rgba(45, 212, 191, 0.16);
+      color: var(--brand);
       padding: 2px 8px;
       border-radius: 999px;
       margin-left: 4px;
@@ -134,10 +151,10 @@
       cursor: pointer;
       transition: all 0.25s ease;
     }
-    .theme-toggle:hover { border-color: var(--violet); }
+    .theme-toggle:hover { border-color: var(--brand); }
 
     .btn-get-pro {
-      background: var(--violet);
+      background: var(--brand-solid);
       color: #fff;
       font-family: 'Space Grotesk', system-ui, sans-serif;
       font-weight: 600;
@@ -152,6 +169,12 @@
 
     /* Floating cluster labels */
     .cluster-label {
+      /* Rendered as a <button> for keyboard access — reset the UA styling that
+         brings, and guarantee a visible focus ring rather than relying on the
+         browser default over a WebGL backdrop. */
+      appearance: none;
+      -webkit-appearance: none;
+      text-align: left;
       position: absolute;
       z-index: 20;
       pointer-events: auto;
@@ -178,8 +201,13 @@
       opacity: 1;
       transform: scale(1);
     }
+    .cluster-label:focus-visible {
+      outline: 3px solid var(--brand);
+      outline-offset: 3px;
+      border-color: var(--brand);
+    }
     .cluster-label:hover {
-      border-color: var(--violet);
+      border-color: var(--brand);
       transform: scale(1.05);
       box-shadow: 0 0 20px rgba(124, 58, 237, 0.2);
     }
@@ -195,7 +223,13 @@
       bottom: 32px;
       left: 50%;
       transform: translateX(-50%);
-      z-index: 20;
+      z-index: 25;   /* above .cluster-label (20) — the hero copy wins */
+      padding: 14px 22px;
+      border-radius: 16px;
+      background: var(--bg-panel);
+      backdrop-filter: blur(var(--panel-blur));
+      max-width: min(680px, 92vw);
+      text-align: center;
       font-family: 'Space Grotesk', system-ui, sans-serif;
       font-size: 14px;
       color: var(--text-muted);
@@ -257,7 +291,7 @@
       cursor: pointer;
       transition: all 0.25s ease;
     }
-    .feature-panel .back-btn:hover { border-color: var(--violet); }
+    .feature-panel .back-btn:hover { border-color: var(--brand); }
 
     .feature-panel .feature-tag {
       font-family: 'JetBrains Mono', monospace;
@@ -364,7 +398,7 @@
       transition: all 0.25s ease;
     }
     .price-card.featured {
-      border-color: var(--violet);
+      border-color: var(--brand);
       box-shadow: 0 0 30px rgba(124, 58, 237, 0.15);
     }
     .price-card h3 {
@@ -410,7 +444,7 @@
     }
     .btn-checkout:hover { filter: brightness(1.1); }
     .btn-checkout.primary {
-      background: var(--violet);
+      background: var(--brand-solid);
       color: #fff;
     }
     .btn-checkout.secondary {
@@ -419,7 +453,7 @@
       color: var(--text);
     }
     .btn-checkout.secondary:hover {
-      border-color: var(--violet);
+      border-color: var(--brand);
     }
 
     /* Compare table in panel */
@@ -442,7 +476,7 @@
       border-bottom: 1px solid rgba(128,128,128,0.1);
     }
     .compare-table td:last-child {
-      color: var(--violet);
+      color: var(--brand);
       font-weight: 600;
     }
 
@@ -509,13 +543,13 @@
       outline: none;
       transition: border-color 0.25s;
     }
-    .modal-box input:focus { border-color: var(--violet); }
+    .modal-box input:focus { border-color: var(--brand); }
     .modal-box .btn-submit {
       width: 100%;
       padding: 12px;
       border-radius: 12px;
       border: none;
-      background: var(--violet);
+      background: var(--brand-solid);
       color: #fff;
       font-weight: 600;
       font-size: 14px;
@@ -565,12 +599,61 @@
       cursor: pointer;
     }
 
+    /* Static fallback for a failed 3D scene */
+    #scene-fallback {
+      position: fixed;
+      inset: auto 0 12% 0;
+      z-index: 30;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 14px;
+      padding: 0 20px;
+    }
+    #scene-fallback[hidden] { display: none; }
+    .fallback-note { color: var(--text-muted); font-size: 13px; margin: 0; }
+    .fallback-grid {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      gap: 10px;
+      max-width: 640px;
+    }
+    .fallback-grid button {
+      appearance: none;
+      min-height: 44px;
+      padding: 10px 18px;
+      border-radius: 12px;
+      border: 1px solid var(--border);
+      background: var(--bg-card);
+      color: var(--text);
+      font-family: 'Space Grotesk', system-ui, sans-serif;
+      font-size: 13px;
+      font-weight: 600;
+      cursor: pointer;
+    }
+    .fallback-grid button:hover { border-color: var(--brand); }
+    .fallback-grid button:focus-visible {
+      outline: 3px solid var(--brand);
+      outline-offset: 3px;
+    }
+
     /* Mobile responsive */
     @media (max-width: 640px) {
       .feature-panel { width: 100vw; padding: 72px 20px 20px; }
       .center-hint .title { font-size: 22px; }
       .top-bar { padding: 12px 16px; }
-      .btn-get-pro { padding: 8px 14px; font-size: 13px; }
+      /* The bar is a no-wrap flex row holding the logo plus three text links,
+         a 40px toggle and the CTA. At ~375px that overflowed with no fallback,
+         so drop the secondary links and keep the one action that matters. */
+      .top-actions .nav-secondary { display: none; }
+      .btn-get-pro {
+        padding: 12px 16px;
+        font-size: 13px;
+        min-height: 44px;   /* touch target */
+      }
+      .theme-toggle { min-width: 44px; min-height: 44px; }
+      .modal-close { width: 44px; height: 44px; }
     }
 
     /* Reduced motion */
@@ -590,21 +673,21 @@
   <div class="top-bar">
     <a href="https://github.com/nhadaututtheky/neural-memory" target="_blank" rel="noopener" class="logo">
       <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-        <circle cx="12" cy="8" r="3" stroke="var(--violet)" stroke-width="2"/>
+        <circle cx="12" cy="8" r="3" stroke="var(--brand)" stroke-width="2"/>
         <circle cx="6" cy="18" r="2.5" stroke="var(--cyan)" stroke-width="2"/>
         <circle cx="18" cy="18" r="2.5" stroke="var(--pink)" stroke-width="2"/>
-        <line x1="12" y1="11" x2="7" y2="16" stroke="var(--violet)" stroke-width="1.5" opacity="0.5"/>
+        <line x1="12" y1="11" x2="7" y2="16" stroke="var(--brand)" stroke-width="1.5" opacity="0.5"/>
         <line x1="12" y1="11" x2="17" y2="16" stroke="var(--cyan)" stroke-width="1.5" opacity="0.5"/>
       </svg>
-      Neural<span style="color:var(--violet)">Memory</span>
+      Neural<span style="color:var(--brand)">Memory</span>
       <span class="pro-badge">PRO</span>
     </a>
     <div class="top-actions">
-      <a href="https://neuralmemory.theio.vn/getting-started/quickstart/" target="_blank" rel="noopener"
+      <a class="nav-secondary" href="https://neuralmemory.theio.vn/getting-started/quickstart/" target="_blank" rel="noopener"
          style="color:var(--text-muted);font-size:13px;text-decoration:none;">Docs</a>
-      <a href="https://github.com/nhadaututtheky/neural-memory" target="_blank" rel="noopener"
+      <a class="nav-secondary" href="https://github.com/nhadaututtheky/neural-memory" target="_blank" rel="noopener"
          style="color:var(--text-muted);font-size:13px;text-decoration:none;">GitHub</a>
-      <a href="https://github.com/nhadaututtheky/neural-memory#quick-start" target="_blank" rel="noopener"
+      <a class="nav-secondary" href="https://github.com/nhadaututtheky/neural-memory#quick-start" target="_blank" rel="noopener"
          style="color:var(--emerald);font-size:13px;text-decoration:none;font-weight:600;">Install Free</a>
       <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">
         <svg id="theme-icon-dark" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>
@@ -617,7 +700,7 @@
   <!-- Center hint (visible when no panel is open) -->
   <div class="center-hint" id="center-hint">
     <div class="title">Your agent's brain,<br>upgraded</div>
-    <div class="subtitle">Free forever &mdash; 52 tools, unlimited memories. Pro for semantic search &amp; scale.</div>
+    <div class="subtitle">Free forever &mdash; 63 tools, unlimited memories. Pro for semantic search &amp; scale.</div>
     <div class="subtitle" style="font-size:13px;margin-top:4px;">Click a neuron cluster to explore Pro features</div>
     <div class="drag-icon">
       <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--text-muted)" stroke-width="1.5">
@@ -627,31 +710,45 @@
     </div>
   </div>
 
+  <!-- Shown only if the WebGL module fails to load (CDN down, no WebGL, JS
+       module error). Without this the page is unusable in those cases. -->
+  <div id="scene-fallback" hidden>
+    <p class="fallback-note">Interactive view unavailable &mdash; browse the features directly:</p>
+    <div class="fallback-grid">
+      <button type="button" onclick="showFeature('cone')">Cone Queries</button>
+      <button type="button" onclick="showFeature('merge')">Smart Merge</button>
+      <button type="button" onclick="showFeature('compress')">Directional Compression</button>
+      <button type="button" onclick="showFeature('tiers')">5-Tier Lifecycle</button>
+      <button type="button" onclick="showFeature('engine')">InfinityDB Engine</button>
+      <button type="button" onclick="showFeature('pricing')">Pricing</button>
+    </div>
+  </div>
+
   <!-- Cluster labels (positioned by JS to track 3D positions) -->
-  <div id="label-cone" class="cluster-label" data-feature="cone">
-    <span class="dot" style="background:var(--violet)"></span>
+  <button type="button" id="label-cone" class="cluster-label" data-feature="cone">
+    <span class="dot" aria-hidden="true" style="background:var(--violet)"></span>
     Cone Queries
-  </div>
-  <div id="label-merge" class="cluster-label" data-feature="merge">
-    <span class="dot" style="background:var(--emerald)"></span>
+  </button>
+  <button type="button" id="label-merge" class="cluster-label" data-feature="merge">
+    <span class="dot" aria-hidden="true" style="background:var(--emerald)"></span>
     Smart Merge
-  </div>
-  <div id="label-compress" class="cluster-label" data-feature="compress">
-    <span class="dot" style="background:var(--pink)"></span>
+  </button>
+  <button type="button" id="label-compress" class="cluster-label" data-feature="compress">
+    <span class="dot" aria-hidden="true" style="background:var(--pink)"></span>
     Directional Compression
-  </div>
-  <div id="label-tiers" class="cluster-label" data-feature="tiers">
-    <span class="dot" style="background:var(--amber)"></span>
+  </button>
+  <button type="button" id="label-tiers" class="cluster-label" data-feature="tiers">
+    <span class="dot" aria-hidden="true" style="background:var(--amber)"></span>
     5-Tier Lifecycle
-  </div>
-  <div id="label-engine" class="cluster-label" data-feature="engine">
-    <span class="dot" style="background:var(--cyan)"></span>
+  </button>
+  <button type="button" id="label-engine" class="cluster-label" data-feature="engine">
+    <span class="dot" aria-hidden="true" style="background:var(--cyan)"></span>
     InfinityDB Engine
-  </div>
-  <div id="label-pricing" class="cluster-label" data-feature="pricing">
-    <span class="dot" style="background:var(--pulse)"></span>
+  </button>
+  <button type="button" id="label-pricing" class="cluster-label" data-feature="pricing">
+    <span class="dot" aria-hidden="true" style="background:var(--pulse)"></span>
     Pricing
-  </div>
+  </button>
 
   <!-- Feature panel (slides from right) -->
   <div class="feature-panel" id="feature-panel">
@@ -687,20 +784,20 @@
       <button class="modal-close" onclick="closeSepayModal()" aria-label="Close">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
       </button>
-      <h3>Thanh toan QR</h3>
-      <p class="subtitle">Chuyen khoan ngan hang — tu dong kich hoat sau 1-5 phut</p>
+      <h3>Thanh toán QR</h3>
+      <p class="subtitle">Chuyển khoản ngân hàng — tự động kích hoạt sau 1–5 phút</p>
 
       <!-- Step 1: collect email & register order -->
       <div id="sepay-step-email">
-        <label for="sepay-email">Email (de nhan license key) *</label>
+        <label for="sepay-email">Email (để nhận license key) *</label>
         <input type="email" id="sepay-email" required placeholder="you@example.com">
         <label for="sepay-github">GitHub username (optional)</label>
         <input type="text" id="sepay-github" placeholder="octocat">
         <p style="color:var(--text-muted);font-size:11px;margin:8px 0 12px;">
-          Email la BAT BUOC truoc khi hien QR — license key se duoc gui ve dia chi nay.
+          Email là <strong>bắt buộc</strong> trước khi hiện QR — license key sẽ được gửi về địa chỉ này.
         </p>
-        <button class="btn-confirm-sepay" id="sepay-register-btn" onclick="registerSepayOrder()">Tao ma & Hien QR</button>
-        <div id="sepay-error" style="color:var(--rose);font-size:12px;margin-top:8px;display:none;"></div>
+        <button class="btn-confirm-sepay" id="sepay-register-btn" onclick="registerSepayOrder()">Tạo mã &amp; Hiện QR</button>
+        <div id="sepay-error" style="color:var(--danger);font-size:12px;margin-top:8px;display:none;"></div>
       </div>
 
       <!-- Step 2: QR + transfer instructions (hidden until order registered) -->
@@ -709,13 +806,13 @@
           <img id="sepay-qr" src="" alt="QR thanh toan" width="220" height="220">
         </div>
         <div class="sepay-info">
-          <div class="row"><span>So tien:</span><span class="value" id="sepay-amount">219,000 VND</span></div>
-          <div class="row"><span>Noi dung CK:</span><span class="value" id="sepay-content" style="color:var(--violet);font-size:11px;">NM-PRO-MONTHLY-XXXXXXXX</span></div>
-          <div class="row"><span>Gui den:</span><span class="value" id="sepay-recipient-email" style="font-size:11px;"></span></div>
+          <div class="row"><span>Số tiền:</span><span class="value" id="sepay-amount">219,000 VND</span></div>
+          <div class="row"><span>Nội dung CK:</span><span class="value" id="sepay-content" style="color:var(--brand);font-size:11px;">NM-PRO-MONTHLY-XXXXXXXX</span></div>
+          <div class="row"><span>Gửi đến:</span><span class="value" id="sepay-recipient-email" style="font-size:11px;"></span></div>
         </div>
         <p style="color:var(--text-muted);font-size:12px;margin-top:12px;">
-          Sau khi chuyen khoan thanh cong, license key se duoc gui ve email trong vong 1-5 phut.<br>
-          QUAN TRONG: noi dung chuyen khoan phai giu nguyen (du ngan hang co the bo dau gach).
+          Sau khi chuyển khoản thành công, license key sẽ được gửi về email trong vòng 1–5 phút.<br>
+          <strong>QUAN TRỌNG:</strong> nội dung chuyển khoản phải giữ nguyên (dù ngân hàng có thể bỏ dấu gạch).
         </p>
       </div>
 
@@ -1027,8 +1124,18 @@
           continue;
         }
 
-        const x = (projected.x * 0.5 + 0.5) * window.innerWidth;
-        const y = (-projected.y * 0.5 + 0.5) * window.innerHeight;
+        let x = (projected.x * 0.5 + 0.5) * window.innerWidth;
+        let y = (-projected.y * 0.5 + 0.5) * window.innerHeight;
+
+        // Clamp into the viewport. The labels are centred on their own width via
+        // translate(-50%,-50%), so a cluster near the edge of a narrow screen
+        // projected them half off-screen and clipped the text — on a 375px
+        // viewport several sat at negative left. Measure and keep them inside.
+        const halfW = el.offsetWidth / 2;
+        const halfH = el.offsetHeight / 2;
+        const pad = 8;
+        x = Math.min(Math.max(x, halfW + pad), window.innerWidth - halfW - pad);
+        y = Math.min(Math.max(y, halfH + pad), window.innerHeight - halfH - pad);
 
         el.style.left = x + 'px';
         el.style.top = y + 'px';
@@ -1145,6 +1252,9 @@
       document.querySelectorAll('.cluster-label').forEach(el => el.classList.add('visible'));
     }, 500);
 
+    // Tells the fallback below that the scene came up, so it stays hidden.
+    window.__sceneReady = true;
+
     // Reduced motion
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
       controls.autoRotate = false;
@@ -1153,16 +1263,44 @@
 
   <!-- ─── Panel Content Templates + Payment Logic ──── -->
   <script>
+    /* Baseline panel controls, defined in a CLASSIC script so they exist even
+       when the WebGL module never runs. This block is parsed before the
+       deferred module, so on a healthy load the module overwrites both with its
+       camera-animating versions; on a failed load these remain and the panels
+       still open. Without them the fallback buttons below would throw. */
+    window.showFeature = function (featureKey) {
+      document.getElementById('panel-content').innerHTML = getPanelHTML(featureKey);
+      document.getElementById('feature-panel').classList.add('open');
+      document.getElementById('center-hint').style.opacity = '0';
+    };
+    window.closePanel = function () {
+      document.getElementById('feature-panel').classList.remove('open');
+      document.getElementById('center-hint').style.opacity = '1';
+    };
+
+    /* Reveal the static feature list if the scene never signalled readiness. */
+    window.addEventListener('load', function () {
+      setTimeout(function () {
+        if (window.__sceneReady) return;
+        var fb = document.getElementById('scene-fallback');
+        if (fb) fb.hidden = false;
+        var hint = document.querySelector('.center-hint .drag-icon');
+        if (hint) hint.style.display = 'none';
+        var cta = document.querySelector('.center-hint .subtitle:last-of-type');
+        if (cta) cta.textContent = 'Browse Pro features below';
+      }, 4000);
+    });
+
     // === FEATURE PANEL CONTENT ===
     function getPanelHTML(key) {
       const panels = {
         cone: `
-          <div class="feature-tag" style="color:var(--violet)">CONE QUERIES</div>
+          <div class="feature-tag" style="color:var(--violet-text)">CONE QUERIES</div>
           <h2>Adjustable Semantic Recall</h2>
           <p>Instead of matching keywords, Cone Queries search a <strong>semantic cone</strong> around your query embedding. Narrow it for precision, widen it for exploration.</p>
           <div class="stat-grid">
             <div class="stat-card">
-              <div class="stat-value" style="color:var(--violet)">7/7</div>
+              <div class="stat-value" style="color:var(--violet-text)">7/7</div>
               <div class="stat-label">Relevant memories found</div>
             </div>
             <div class="stat-card">
@@ -1172,7 +1310,7 @@
           </div>
           <p><strong>How scoring works:</strong></p>
           <div class="code-block">
-            <span style="color:var(--text-muted)">combined_score</span> = <span style="color:var(--violet)">similarity</span> &times; 0.7 + <span style="color:var(--cyan)">activation</span> &times; 0.3
+            <span style="color:var(--text-muted)">combined_score</span> = <span style="color:var(--violet-text)">similarity</span> &times; 0.7 + <span style="color:var(--cyan)">activation</span> &times; 0.3
           </div>
           <p>A memory can be semantically relevant (high similarity) even if rarely accessed. A frequently accessed memory gets a boost even at moderate similarity.</p>
           <div class="code-block">
@@ -1259,7 +1397,7 @@
               <span class="tier-bytes">1,536 B</span>
             </div>
             <div class="tier-row">
-              <span class="tier-name" style="color:var(--violet)">WARM</span>
+              <span class="tier-name" style="color:var(--violet-text)">WARM</span>
               <div class="tier-bar-bg"><div class="tier-bar-fill" style="width:50%;background:var(--violet)"></div></div>
               <span class="tier-bytes">768 B</span>
             </div>
@@ -1300,7 +1438,7 @@
           <p>Not a wrapper around SQLite. A <strong>custom storage engine</strong> designed for one job: neural memory graphs.</p>
           <div class="code-block">
             <div><span style="color:var(--cyan)">brain.inf</span>&nbsp;&nbsp;&nbsp;Header (magic + version + dims)</div>
-            <div><span style="color:var(--violet)">brain.vec</span>&nbsp;&nbsp;&nbsp;Memory-mapped vectors (numpy mmap)</div>
+            <div><span style="color:var(--violet-text)">brain.vec</span>&nbsp;&nbsp;&nbsp;Memory-mapped vectors (numpy mmap)</div>
             <div><span style="color:var(--emerald)">brain.idx</span>&nbsp;&nbsp;&nbsp;HNSW index (M=16, ef=200)</div>
             <div><span style="color:var(--pink)">brain.graph</span>&nbsp;Directed synapse edges (msgpack)</div>
             <div><span style="color:var(--amber)">brain.meta</span>&nbsp;&nbsp;Neuron metadata (O(1) lookup)</div>
@@ -1318,19 +1456,19 @@
           </div>
           <table class="compare-table">
             <tr><th></th><th>Free (SQLite)</th><th>Pro (InfinityDB)</th></tr>
-            <tr><td>Recall</td><td>Keyword (FTS5)</td><td style="color:var(--violet)">Semantic (HNSW)</td></tr>
-            <tr><td>Speed (10K)</td><td>~500ms</td><td style="color:var(--violet)">&lt;5ms</td></tr>
-            <tr><td>Scale</td><td>~50K</td><td style="color:var(--violet)">2M+</td></tr>
-            <tr><td>Storage (1M)</td><td>~5 GB</td><td style="color:var(--violet)">~1 GB</td></tr>
-            <tr><td>Graph</td><td>SQL JOINs</td><td style="color:var(--violet)">Native BFS &lt;1ms</td></tr>
-            <tr><td>Crash recovery</td><td>SQLite WAL</td><td style="color:var(--violet)">Custom WAL + replay</td></tr>
-            <tr><td>MCP tools</td><td>52</td><td style="color:var(--violet)">52 + 3 Pro</td></tr>
+            <tr><td>Recall</td><td>Keyword (FTS5)</td><td style="color:var(--brand)">Semantic (HNSW)</td></tr>
+            <tr><td>Speed (10K)</td><td>~500ms</td><td style="color:var(--brand)">&lt;5ms</td></tr>
+            <tr><td>Scale</td><td>~50K</td><td style="color:var(--brand)">2M+</td></tr>
+            <tr><td>Storage (1M)</td><td>~5 GB</td><td style="color:var(--brand)">~1 GB</td></tr>
+            <tr><td>Graph</td><td>SQL JOINs</td><td style="color:var(--brand)">Native BFS &lt;1ms</td></tr>
+            <tr><td>Crash recovery</td><td>SQLite WAL</td><td style="color:var(--brand)">Custom WAL + replay</td></tr>
+            <tr><td>MCP tools</td><td>63</td><td style="color:var(--brand)">63 + 3 Pro</td></tr>
           </table>
           <div style="margin-top:20px">
             <div class="code-block">
-              <span style="color:var(--text-muted)">$</span> <span style="color:var(--emerald)">pip install</span> <span style="color:var(--violet)">neural-memory-pro</span>
+              <span style="color:var(--text-muted)">$</span> <span style="color:var(--emerald)">pip install</span> <span style="color:var(--violet-text)">neural-memory-pro</span>
             </div>
-            <p style="font-size:13px">Auto-registers via entry points. All 52 free tools keep working. Three new tools appear automatically.</p>
+            <p style="font-size:13px">Auto-registers via entry points. All 63 free tools keep working. Three new tools appear automatically.</p>
           </div>
         `,
         pricing: `
@@ -1342,10 +1480,10 @@
               <div class="price" style="color:var(--text)">$0</div>
               <div class="period">forever</div>
               <ul>
-                <li><span class="check">&#10003;</span> 52 MCP tools</li>
+                <li><span class="check">&#10003;</span> 63 MCP tools</li>
                 <li><span class="check">&#10003;</span> SQLite storage + FTS5 search</li>
                 <li><span class="check">&#10003;</span> Spreading activation retrieval</li>
-                <li><span class="check">&#10003;</span> 14 consolidation strategies</li>
+                <li><span class="check">&#10003;</span> 19 consolidation strategies</li>
                 <li><span class="check">&#10003;</span> Cloud sync (100 neurons)</li>
               </ul>
               <a href="https://github.com/nhadaututtheky/neural-memory" target="_blank" rel="noopener"
@@ -1356,10 +1494,10 @@
               </div>
             </div>
             <div class="price-card featured">
-              <div style="font-size:11px;font-weight:700;color:var(--violet);margin-bottom:8px">POPULAR</div>
+              <div style="font-size:11px;font-weight:700;color:var(--brand);margin-bottom:8px">POPULAR</div>
               <h3>Pro</h3>
-              <div class="price" style="color:var(--violet)">$9<span class="period">/month</span></div>
-              <div class="period">or $89/year (save $19) &bull; 219,000 VND/thang</div>
+              <div class="price" style="color:var(--brand)">$9<span class="period">/month</span></div>
+              <div class="period">or $89/year (save $19) &bull; 219.000₫/tháng</div>
               <ul>
                 <li><span class="check">&#10003;</span> Everything in Free</li>
                 <li><span class="check">&#10003;</span> <strong style="color:var(--text)">InfinityDB engine</strong> (HNSW)</li>
@@ -1372,7 +1510,7 @@
               </ul>
               <button class="btn-checkout primary" onclick="startPolarCheckout('NM-PRO-MONTHLY')">Get Pro &mdash; $9/mo (Card / PayPal)</button>
               <button class="btn-checkout secondary" onclick="startPolarCheckout('NM-PRO-YEARLY')">Yearly &mdash; $89/yr (save $19)</button>
-              <button class="btn-checkout secondary" onclick="showSepayModal('NM-PRO-MONTHLY', 219000)">Thanh toan QR &mdash; 219,000d/thang (VN)</button>
+              <button class="btn-checkout secondary" onclick="showSepayModal('NM-PRO-MONTHLY', 219000)">Thanh toán QR &mdash; 219.000₫/tháng (VN)</button>
             </div>
             <div class="price-card">
               <h3>Team</h3>
@@ -1392,10 +1530,10 @@
           <p style="font-size:13px;text-align:center">30-day money-back guarantee. No questions asked.</p>
           <div style="margin-top:28px;padding-top:24px;border-top:1px solid var(--border)">
             <h3 style="font-size:16px;margin-bottom:12px">After Purchase</h3>
-            <p style="font-size:13px;color:var(--text-muted);margin-bottom:12px">You'll receive a license key (<code style="color:var(--violet)">NM-PRO-XXXX-XXXX-XXXX</code>) via email. Then:</p>
+            <p style="font-size:13px;color:var(--text-muted);margin-bottom:12px">You'll receive a license key (<code style="color:var(--brand)">NM-PRO-XXXX-XXXX-XXXX</code>) via email. Then:</p>
             <div class="code-block" style="font-size:12px;line-height:1.8">
               <div style="color:var(--text-muted)"># 1. Activate (just one command)</div>
-              <div><span style="color:var(--emerald)">nmem shared activate</span> --key <span style="color:var(--violet)">NM-PRO-XXXX-XXXX-XXXX</span></div>
+              <div><span style="color:var(--emerald)">nmem shared activate</span> --key <span style="color:var(--brand)">NM-PRO-XXXX-XXXX-XXXX</span></div>
               <br>
               <div style="color:var(--text-muted)"># 2. Optional: upgrade to InfinityDB</div>
               <div><span style="color:var(--emerald)">nmem storage status</span></div>
@@ -1527,12 +1665,12 @@
       errEl.style.display = 'none';
 
       if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
-        showSepayError('Vui long nhap email hop le.');
+        showSepayError('Vui lòng nhập email hợp lệ.');
         return;
       }
 
       btn.disabled = true;
-      btn.textContent = 'Dang tao ma...';
+      btn.textContent = 'Đang tạo mã…';
 
       // Generate order code client-side, then register on the hub
       sepayOrderCode = generateOrderCode(currentProduct);
@@ -1552,7 +1690,7 @@
 
         if (!res.ok) {
           const data = await res.json().catch(() => ({}));
-          throw new Error(data.error || 'Khong dang ky duoc ma. Vui long thu lai.');
+          throw new Error(data.error || 'Không đăng ký được mã. Vui lòng thử lại.');
         }
 
         // Success — switch to QR step
@@ -1562,11 +1700,11 @@
         document.getElementById('sepay-step-email').style.display = 'none';
         document.getElementById('sepay-step-qr').style.display = '';
       } catch (err) {
-        showSepayError(err.message || 'Loi ket noi. Vui long thu lai.');
+        showSepayError(err.message || 'Lỗi kết nối. Vui lòng thử lại.');
         sepayOrderCode = '';
       } finally {
         btn.disabled = false;
-        btn.textContent = 'Tao ma & Hien QR';
+        btn.textContent = 'Tạo mã & Hiện QR';
       }
     }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,7 +162,7 @@ docs = [
 
 [project.urls]
 Homepage = "https://neuralmemory.theio.vn"
-Documentation = "https://nhadaututtheky.github.io/neural-memory"
+Documentation = "https://neuralmemory.theio.vn"
 Repository = "https://github.com/nhadaututtheky/neural-memory"
 Issues = "https://github.com/nhadaututtheky/neural-memory/issues"
 Changelog = "https://github.com/nhadaututtheky/neural-memory/blob/main/CHANGELOG.md"


### PR DESCRIPTION
Three asks: refresh the repo's opening, check the landing page, and cover `nm update`. All three turned up real defects.

## Landing page — two failure modes, not just styling

**Keyboard users could reach one panel out of six.** The feature labels were plain `<div>`s with click handlers; the 3D scene's raycaster was the only other route and it is mouse-only. Five of the six panels — including everything describing what Pro actually does — were unreachable. Hard WCAG 2.1.1 failure. They are real `<button>`s now, with a focus ring that survives the WebGL backdrop.

**A CDN outage made the page a blank canvas.** The whole scene depends on a three.js importmap from jsdelivr with no integrity hash. If that fetch fails the module never runs, labels never get `.visible`, and there is no way into the content. Added a static feature list that appears if the scene doesn't signal readiness in 4s, plus baseline `showFeature`/`closePanel` in a classic script so those buttons work without the module.

**Brand + contrast.** The page was violet `#7c3aed` while the dashboard just moved to teal — they read as different products. And `#7c3aed` on the `#0e0e24` card measures **3.33:1**, so it failed AA everywhere it was text: the entire "Pro" column of the comparison table, and the bank-transfer reference code users must transcribe correctly. Now `--brand` is theme-aware (`#2dd4bf` dark / `#0f766e` light), the six categorical cluster hues stay, and `--violet-text` covers categorical text that should stay violet but readable. Graphical fills keep `#7c3aed` — 3.33:1 clears the 3:1 non-text bar.

**Wrong numbers**, verified against source:
| Claim | Was | Is |
|---|---|---|
| MCP tools (4 places) | 52 | **63** (`tests/unit/test_tool_tiers.py`) |
| Consolidation strategies | 14 | **19** free + Pro `smart_merge` |

**Also:** `--rose` was referenced but never defined, so the payment error message rendered in the inherited body color instead of red. Vietnamese copy was written without diacritics ("Thanh toan QR") — restored, deliberately leaving the bank transfer *memo* ASCII since some banks strip marks. Mobile: top bar overflowed at 375px and projected labels clipped off both edges; fixed with wrapping, collapsed secondary links, viewport clamping and 44px touch targets. The hero copy and the lowest cluster label were drawn on top of each other.

## Repo opening

- **Nothing said the project has a website.** Added a nav line under the tagline: Website / Quickstart / MCP Tools / Pro / Changelog, all verified 200.
- README linked docs **17 times** via `nhadaututtheky.github.io` while `mkdocs.yml` declares `neuralmemory.theio.vn` as canonical and `pyproject`'s Homepage already used it — only its `Documentation` entry didn't. Both now point at the branded domain.
- Pro badge on the docs index used `#6366f1`, the stock indigo the project's own design rules forbid by name.

## `nmem update`

It already exists and works (`nmem update --check` → "Already up to date"), but appeared nowhere outside the generated CLI reference. Documented in the intro, along with the fact that the binary is **`nmem`** — there is no `nm`.

## A broken instruction this turned up

README told users to run `nmem pro activate YOUR_LICENSE_KEY` in **three places**. That command does not exist — it errors with *"No such command 'pro'"*. The real one is `nmem shared activate --key NM-PRO-XXXX-XXXX-XXXX`. Anyone who bought Pro and followed the README could not activate. Also corrected the stale CLI count (82, not 66 — the generated doc says 82).

## Verification
- New `dashboard/e2e/landing.spec.ts` pins the three regressions that matter: Enter on a focused cluster button opens a panel, the fallback appears **and works** with the CDN blocked, and no label clips at 375px.
- **11/11 e2e pass**, zero console errors. HTML nesting validated with a parser. Contrast values computed, not eyeballed.
