### PR TITLE
chore: release 4.60.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "Reflex-based memory system for AI agents. Stores experiences as interconnected neurons, recalls through spreading activation — not search.",
-    "version": "4.59.1"
+    "version": "4.60.0"
   },
   "plugins": [
     {
@@ -18,7 +18,7 @@
         "repo": "nhadaututtheky/neural-memory"
       },
       "description": "Reflex-based memory system for AI agents — stores experiences as interconnected neurons and recalls them through spreading activation, mimicking how the human brain works.",
-      "version": "4.59.1",
+      "version": "4.60.0",
       "author": {
         "name": "NeuralMemory Contributors"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "neural-memory",
   "displayName": "Neural Memory",
-  "version": "4.59.1",
+  "version": "4.60.0",
   "description": "Reflex-based memory system for AI agents — stores experiences as interconnected neurons and recalls them through spreading activation, mimicking how the human brain works.",
   "author": {
     "name": "NeuralMemory Contributors"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,98 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.60.0] — 2026-07-28
+
+### Fixed — Pruned memories were never actually hidden from recall
+
+`lifecycle_state` is a derived column: no retrieval path reads it, and the
+`lifecycle` consolidation strategy recomputes it from heat and age on every run.
+Both prune scripts wrote only that column, so everything they "pruned" stayed
+fully recallable — and the marker was erased by the next consolidation pass.
+
+- Recall visibility is gated solely by `metadata._status`. Both scripts now set
+  it, stashing the prior value in `metadata._prev_status` for a faithful
+  `--unprune`. Re-running repairs rows an older version marked `stale`.
+- Session-dump text reaches recall through three independent surfaces:
+  `neurons.content`, `fibers.summary` and `fibers.essence`. Only the first was
+  covered; the other two kept leaking whole transcripts into recall.
+- Dump neurons are matched by signature anywhere in the text, not just as a
+  prefix — concept extraction re-emitted transcript fragments starting with
+  `Duration = 74s` or `User`, which a prefix rule never saw. Length is
+  deliberately not a signal: the longest neurons in a real brain were imported
+  legal texts and tax records.
+- The shared marker logic now lives in `scripts/_prune_status.py`; the bug
+  existed twice because the logic was copied.
+- Fixed a `UnicodeEncodeError` that aborted a run mid-way through on a cp1252
+  console when previewing non-ASCII content.
+- `lifecycle_state` documented as derived and consolidation-owned in the SQLite
+  and Postgres schemas.
+
 ### Fixed — Consolidation summary_fiber self-amplifying pollution loop
 
-- **`_summarize()` no longer creates tag-repetition pollution.** The method now
-  excludes existing `summary_fiber` entries from the clustering pool to prevent
-  a self-amplifying loop where each cycle re-ingested the previous cycle's output.
-- **Tag-repetition pattern detection.** Source fiber summaries matching the
-  signature `[tag1, tag2] [tag1, tag2] ...` are now filtered out before
-  constructing the cluster's concept content, preventing nested bracket pollution.
-- **`_essence_backfill()` rejects polluted anchor content.** The same
-  tag-repetition pattern check is applied to anchor neuron content before
-  generating essence, preventing propagation of pollution into the essence field.
+Contributed by @SparkofSpike.
+
+- `_summarize()` excludes existing `summary_fiber` entries from the clustering
+  pool. They carry their source cluster's tags, so each cycle re-ingested the
+  previous cycle's output and nested the `[tags]` prefix exponentially.
+- Summaries matching the tag-repetition signature are filtered before building
+  concept content, and `_essence_backfill()` skips polluted anchors.
+
+### Fixed — Dashboard rendered a blank page in development
+
+`main.tsx` hardcoded the router basename to `/ui` unless the path was
+`/dashboard`, but Vite dev serves at the root, so the basename never matched and
+`npm run dev` produced an empty tree. This had quietly reduced the Playwright
+suite to 1 of 8 passing; it is 11 of 11 now.
+
+### Added — Living Brain 3D has actual anatomy
+
+The brain was an icosphere stretched to an ellipsoid with two sine terms. It now
+has procedurally generated gyri and sulci, a longitudinal fissure separating the
+hemispheres, a cerebellum with a transverse seam, and a brainstem — with no new
+dependency and no model asset. The mesh and the layout containment force
+evaluate the same surface function, so nodes tuck into the folds instead of
+poking through them.
+
+Node position now means something: regions are assigned to communities detected
+from the synapse graph by weighted label propagation, replacing a fixed
+neuron-type-to-axis lookup that duplicated the color channel.
+
+### Changed — One design system across dashboard and site
+
+- Six competing color palettes collapsed into one module with a per-axis
+  no-duplicate-hex invariant. `entity` used to render as two different colors
+  depending on the page, one of which meant `attribute` elsewhere.
+- Brand primary moved off the stock `#6366f1` indigo, which failed WCAG AA
+  (4.47:1 for white label text). The landing page moved with it.
+- Sidebar and command palette now share one navigation list. `/living-brain`
+  had no sidebar entry at all, and PRO badges marked six items when only two
+  pages are wholly gated.
+
+### Fixed — Landing page accessibility and unverifiable claims
+
+- The six feature labels were `<div>`s with click handlers and were the only
+  route to five of the six panels, so keyboard and screen-reader users could
+  reach exactly one. They are buttons now.
+- The scene depends on a CDN importmap with no fallback; a failed fetch left a
+  blank canvas with no way into the content. Added a static feature list.
+- Benchmark numbers audited against the artifacts in `scripts/`. "2M+ neurons
+  tested" was false — the largest completed run is ~5.5K neurons and the 1M
+  attempt aborted at 250K. `<5ms` described the index lookup, not end-to-end
+  recall (measured p50: 47ms). Compression savings had no benchmark at all and
+  are now labelled as modelled.
+
+### Fixed — Documentation pointed users at a command that does not exist
+
+The README told users to run `nmem pro activate` in three places. There is no
+`nmem pro` command; activation is `nmem shared activate --key NM-PRO-…`. Anyone
+who bought Pro and followed the README could not activate it.
+
+- README now links the website, which it never mentioned, and documents
+  `nmem update`.
+- Documentation links point at the canonical `neuralmemory.theio.vn` declared in
+  `mkdocs.yml`, not `github.io`.
+- Stale counts corrected: 82 CLI commands (not 66), 63 MCP tools (not 52).
 
 ## [4.59.1] — 2026-07-22
 

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ Zero LLM calls, zero API cost. [Full benchmarks →](docs/benchmarks.md)
 git clone https://github.com/nhadaututtheky/neural-memory
 cd neural-memory && pip install -e ".[dev]"
 nmem doctor --dev        # Verify contributor setup
-pytest tests/ -v          # 7400+ tests
+pytest tests/ -v          # 7600+ tests
 ruff check src/ tests/    # Lint
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@
 > Every item passes the VISION.md 4-question test + brain test.
 > ZERO LLM dependency — pure algorithmic, regex, graph-based.
 
-**Current state**: v4.31.0 — 63 MCP tools, 7400+ tests, schema v39, SQLite + PostgreSQL + InfinityDB backends, neuroscience engine (10 brain-inspired algorithms), tiered memory (HOT/WARM/COLD + auto-tier + domain boundaries), decision intelligence, 7-module handler architecture, Pro bundled in main package (license-gated), Brain Store community marketplace (GitHub-backed).
+**Current state**: v4.31.0 — 63 MCP tools, 7600+ tests, schema v39, SQLite + PostgreSQL + InfinityDB backends, neuroscience engine (10 brain-inspired algorithms), tiered memory (HOT/WARM/COLD + auto-tier + domain boundaries), decision intelligence, 7-module handler architecture, Pro bundled in main package (license-gated), Brain Store community marketplace (GitHub-backed).
 **Architecture**: Spreading activation reflex engine, biological memory model, MCP standard.
 **Direction**: Feature breadth is sufficient. Future focus shifts to **quality depth** — optimizing every fiber, synapse, and neuron interaction to produce the highest-quality memory graph possible.
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -556,7 +556,7 @@ NeuralMemory is designed for **AI agent memory** — not as a general-purpose da
 
 | Aspect | Status |
 |--------|--------|
-| **Test suite** | 7400+ tests, 67%+ coverage enforced by CI |
+| **Test suite** | 7600+ tests, 67%+ coverage enforced by CI |
 | **Security** | Input validation, ReDoS protection, activation queue caps, sensitive content detection |
 | **Stability** | 51+ releases, used daily by the maintainers in production AI workflows |
 | **Scalability** | Tested up to 5,000 neurons with sub-ms latency; designed for agent-scale data, not big data |

--- a/docs/landing/pricing.md
+++ b/docs/landing/pricing.md
@@ -31,7 +31,7 @@
 
 Everything in Free, plus:
 
-- **InfinityDB engine** — HNSW vector search, <5ms at 1M neurons
+- **InfinityDB engine** — HNSW vector search; <5ms index lookup (measured end-to-end recall p50 47ms at ~5.5K neurons)
 - **Cone Queries** — semantic recall by meaning, not keywords
 - **Smart Merge** — O(N×k) consolidation, scales to 100K+
 - **Directional Compression** — multi-axis semantic preservation

--- a/docs/landing/pro-landing.html
+++ b/docs/landing/pro-landing.html
@@ -599,6 +599,14 @@
       cursor: pointer;
     }
 
+    .claim-note {
+      font-size: 11px;
+      line-height: 1.5;
+      color: var(--text-muted);
+      margin-top: 10px;
+    }
+    .claim-note a { color: var(--brand); }
+
     /* Static fallback for a failed 3D scene */
     #scene-fallback {
       position: fixed;
@@ -1348,19 +1356,22 @@
           <div class="stat-grid">
             <div class="stat-card">
               <div class="stat-value" style="color:var(--emerald)">100x</div>
-              <div class="stat-label">Faster at 100K neurons</div>
+              <div class="stat-label">Projected at 100K neurons</div>
             </div>
             <div class="stat-card">
               <div class="stat-value" style="color:var(--amber)">10s</div>
-              <div class="stat-label">vs 5 hours (Free)</div>
+              <div class="stat-label">vs ~5 hours (projected)</div>
             </div>
           </div>
           <table class="compare-table">
             <tr><th>Neurons</th><th>Free</th><th>Pro</th></tr>
             <tr><td>1,000</td><td>~2s</td><td style="color:var(--emerald)">~0.1s</td></tr>
             <tr><td>10,000</td><td>~3 min</td><td style="color:var(--emerald)">~1s</td></tr>
-            <tr><td>100,000</td><td>~5 hours</td><td style="color:var(--emerald)">~10s</td></tr>
+            <tr><td>100,000*</td><td>~5 hours*</td><td style="color:var(--emerald)">~10s*</td></tr>
           </table>
+          <p class="claim-note">* Projected from the O(N&sup2;) vs O(N log N) complexity difference.
+            Measured runs go up to ~10K neurons &mdash;
+            <a href="https://neuralmemory.theio.vn/benchmarks/">see methodology</a>.</p>
           <div class="code-block">
             <span style="color:var(--cyan)">nmem_pro_merge</span>(
             <br>&nbsp;&nbsp;similarity_threshold=<span style="color:var(--amber)">0.85</span>,
@@ -1424,13 +1435,15 @@
           <div class="stat-grid">
             <div class="stat-card">
               <div class="stat-value" style="color:var(--amber)">92%</div>
-              <div class="stat-label">Savings at 1M neurons</div>
+              <div class="stat-label">Modelled saving at 1M</div>
             </div>
             <div class="stat-card">
               <div class="stat-value" style="color:var(--emerald)">120 MB</div>
-              <div class="stat-label">vs 1.5 GB (Free)</div>
+              <div class="stat-label">vs 1.5 GB (modelled)</div>
             </div>
           </div>
+          <p class="claim-note">Figures are modelled from the per-tier byte sizes above, not measured
+            on a 1M-neuron corpus. Actual saving depends on how your memories distribute across tiers.</p>
         `,
         engine: `
           <div class="feature-tag" style="color:var(--cyan)">INFINITYDB ENGINE</div>
@@ -1447,19 +1460,23 @@
           <div class="stat-grid">
             <div class="stat-card">
               <div class="stat-value" style="color:var(--cyan)">&lt;5ms</div>
-              <div class="stat-label">Search at 1M neurons</div>
+              <div class="stat-label">HNSW vector search</div>
             </div>
             <div class="stat-card">
-              <div class="stat-value" style="color:var(--emerald)">2M+</div>
-              <div class="stat-label">Neurons tested</div>
+              <div class="stat-value" style="color:var(--emerald)">2.8&times;</div>
+              <div class="stat-label">Faster recall than SQLite</div>
             </div>
           </div>
+          <p class="claim-note">&lt;5ms is the ANN index lookup, not end-to-end recall. Measured
+            end-to-end p50 at ~5.5K neurons: <strong>47ms</strong> on InfinityDB vs 134ms on SQLite
+            (<code>scripts/benchmark_backends.py</code>) &mdash;
+            <a href="https://neuralmemory.theio.vn/benchmarks/">methodology</a>.</p>
           <table class="compare-table">
             <tr><th></th><th>Free (SQLite)</th><th>Pro (InfinityDB)</th></tr>
             <tr><td>Recall</td><td>Keyword (FTS5)</td><td style="color:var(--brand)">Semantic (HNSW)</td></tr>
-            <tr><td>Speed (10K)</td><td>~500ms</td><td style="color:var(--brand)">&lt;5ms</td></tr>
-            <tr><td>Scale</td><td>~50K</td><td style="color:var(--brand)">2M+</td></tr>
-            <tr><td>Storage (1M)</td><td>~5 GB</td><td style="color:var(--brand)">~1 GB</td></tr>
+            <tr><td>Recall p50 (~5.5K, measured)</td><td>134ms</td><td style="color:var(--brand)">47ms</td></tr>
+            <tr><td>Design target</td><td>~50K</td><td style="color:var(--brand)">1M+</td></tr>
+            <tr><td>Storage (1M, modelled)</td><td>~5 GB</td><td style="color:var(--brand)">~1 GB</td></tr>
             <tr><td>Graph</td><td>SQL JOINs</td><td style="color:var(--brand)">Native BFS &lt;1ms</td></tr>
             <tr><td>Crash recovery</td><td>SQLite WAL</td><td style="color:var(--brand)">Custom WAL + replay</td></tr>
             <tr><td>MCP tools</td><td>63</td><td style="color:var(--brand)">63 + 3 Pro</td></tr>

--- a/docs/landing/pro.md
+++ b/docs/landing/pro.md
@@ -57,16 +57,16 @@ The difference isn't speed. It's **recall quality**. Your agent remembers by mea
 | | Free (SQLite) | Pro (InfinityDB) |
 |--|---------------|-------------------|
 | **Recall method** | Keyword match (FTS5 BM25) | Semantic similarity (HNSW) |
-| **Search speed** | ~500ms at 10K neurons | **~5ms** at 10K neurons |
+| **Recall p50 (measured, ~5.5K)** | 134ms | **47ms** |
 | **Search quality** | Exact/fuzzy word match | Meaning-based match |
-| **Scale tested** | ~50K neurons | 2M+ neurons |
+| **Largest benchmarked run** | ~5.5K neurons | ~5.5K neurons |
 | **Vector storage** | Not stored | Persistent mmap on disk |
 | **Compression** | Text-level (sentence trimming) | Vector-level (5-tier adaptive) |
 | **Consolidation** | O(N²) brute-force | O(N×k) HNSW neighbor clustering |
 | **Graph traversal** | SQL JOINs per hop | Native adjacency BFS, <1ms |
 | **Crash recovery** | SQLite WAL | Custom WAL + idempotent replay |
-| **MCP tools** | 63 tools | 52 + 3 Pro-exclusive |
-| **Storage per 1M neurons** | ~5 GB | **~1 GB** (with tier compression) |
+| **MCP tools** | 63 tools | 63 + 3 Pro-exclusive |
+| **Storage per 1M neurons (modelled)** | ~5 GB | **~1 GB** (with tier compression) |
 
 ---
 

--- a/docs/promo/hackernews.md
+++ b/docs/promo/hackernews.md
@@ -12,4 +12,4 @@ Core idea: memories are stored as typed neurons connected by typed synapses (CAU
 
 No embedding API calls needed for core recall — it's pure algorithmic graph traversal. Embeddings are optional for cross-language search (supports Ollama, sentence-transformers, Gemini, OpenAI).
 
-63 MCP tools (incl. cognitive reasoning layer), 7400+ tests, SQLite storage, Python 3.11+, MIT license.
+63 MCP tools (incl. cognitive reasoning layer), 7600+ tests, SQLite storage, Python 3.11+, MIT license.

--- a/integrations/neuralmemory/dist/index.js
+++ b/integrations/neuralmemory/dist/index.js
@@ -221,7 +221,7 @@ const plugin = {
     id: "neuralmemory",
     name: "Neural Memory",
     description: "Brain-inspired persistent memory for AI agents — neurons, synapses, and fibers",
-    version: "1.16.0",
+    version: "1.17.0",
     kind: "memory",
     register(api) {
         const cfg = resolveConfig(api.pluginConfig);

--- a/integrations/neuralmemory/openclaw.plugin.json
+++ b/integrations/neuralmemory/openclaw.plugin.json
@@ -3,7 +3,7 @@
   "kind": "memory",
   "name": "Neural Memory",
   "description": "Brain-inspired persistent memory for AI agents — neurons, synapses, and fibers. REQUIRED: set plugins.slots.memory = \"neuralmemory\" in openclaw.json to disable the default memory-core plugin and activate NeuralMemory as the exclusive memory provider.",
-  "version": "1.16.1",
+  "version": "1.17.0",
   "configSchema": {
     "jsonSchema": {
       "type": "object",

--- a/integrations/neuralmemory/package-lock.json
+++ b/integrations/neuralmemory/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neuralmemory",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neuralmemory",
-      "version": "1.16.0",
+      "version": "1.17.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.2.2",

--- a/integrations/neuralmemory/package.json
+++ b/integrations/neuralmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neuralmemory",
-  "version": "1.16.1",
+  "version": "1.17.0",
   "description": "NeuralMemory plugin for OpenClaw — brain-inspired persistent memory for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/integrations/neuralmemory/src/index.ts
+++ b/integrations/neuralmemory/src/index.ts
@@ -322,7 +322,7 @@ const plugin: OpenClawPluginDefinition = {
   name: "Neural Memory",
   description:
     "Brain-inspired persistent memory for AI agents — neurons, synapses, and fibers",
-  version: "1.16.1",
+  version: "1.17.0",
   kind: "memory",
 
   register(api: OpenClawPluginApi): void {

--- a/npm-package/README.md
+++ b/npm-package/README.md
@@ -37,7 +37,7 @@ Add to your `.mcp.json`:
 - **Tiered memory** — HOT/WARM/COLD with auto-tier promotion
 - **3 storage backends** — SQLite, PostgreSQL, InfinityDB (Pro)
 - **Cloud sync** — Cloudflare Workers hub with encryption
-- **7400+ tests**, Python 3.11+, MIT licensed
+- **7600+ tests**, Python 3.11+, MIT licensed
 
 ## Links
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neural-memory"
-version = "4.59.1"
+version = "4.60.0"
 description = "Persistent memory for AI agents — 60 MCP tools, spreading activation recall, neuroscience-inspired consolidation. Works with Claude, GPT, Gemini."
 readme = "README.md"
 license = "MIT"

--- a/src/neural_memory/__init__.py
+++ b/src/neural_memory/__init__.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-__version__ = "4.59.1"
+__version__ = "4.60.0"
 
 # Map public name -> (module, attribute) for lazy resolution.
 _LAZY: dict[str, tuple[str, str]] = {

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import neural_memory
 
-        assert neural_memory.__version__ == "4.59.1"
+        assert neural_memory.__version__ == "4.60.0"
 
 
 class TestPackageIntegrity:

--- a/tests/unit/test_markdown_export.py
+++ b/tests/unit/test_markdown_export.py
@@ -16,7 +16,7 @@ def _make_snapshot(
         "brain_id": "brain-1",
         "brain_name": "test-brain",
         "exported_at": "2026-03-02T12:00:00",
-        "version": "4.59.0",
+        "version": "4.60.0",
         "neurons": neurons or [],
         "synapses": synapses or [],
         "fibers": fibers or [],


### PR DESCRIPTION
Minor bump — the release contains new dashboard/visualization work alongside a set of correctness fixes.

## Also in this PR: unbacked Pro benchmark claims

Audited every hard number on the Pro pages against the actual artifacts in `scripts/`. Three did not survive:

| Claim | Reality |
|---|---|
| "2M+ neurons tested" | Largest run that **completed** is ~5.5K neurons. `scripts/benchmark_1m_output.log` shows the 1M attempt aborting at 250K with a `PermissionError`. |
| "<5ms" search | That is the HNSW index lookup, not recall. Measured end-to-end p50 at ~5.5K: **47ms** InfinityDB vs 134ms SQLite. |
| "92% savings / 120 MB vs 1.5 GB" | **No compression benchmark exists in the repo.** Pure projection. |

Replaced with measured figures where they exist, relabelled as *modelled* or *projected* where they don't, and linked the methodology page. The 100K consolidation row is an extrapolation from the O(N²) vs O(N log N) difference and is now footnoted instead of sitting beside measured rows as though it were one. Same corrections applied to `docs/landing/pro.md` and `pricing.md`.

These are commercial pages — a number that cannot be reproduced from this repo should not be presented as measured.

## Release contents

**Fixed — pruned memories were never actually hidden.** `lifecycle_state` is derived: nothing reads it, and the `lifecycle` consolidation strategy recomputes it every run. Both prune scripts wrote only that column, so everything they "pruned" stayed recallable and the marker was erased anyway. Recall is gated by `metadata._status`. Dump text also reached recall through three surfaces (`neurons.content`, `fibers.summary`, `fibers.essence`) where only the first was covered.

**Fixed — consolidation `summary_fiber` pollution loop** (contributed by @SparkofSpike). Summary fibers carry their source cluster's tags, so each cycle re-ingested the previous cycle's output and nested the `[tags]` prefix exponentially.

**Fixed — dashboard rendered a blank page in dev.** The router basename never matched the Vite dev root. This had quietly reduced the Playwright suite to 1/8 passing; it is 11/11 now.

**Added — Living Brain 3D has actual anatomy.** Procedural gyri and sulci, a longitudinal fissure, a cerebellum with a transverse seam, a brainstem — no new dependency, no model asset. Node position now reflects synapse-graph communities instead of a fixed type-to-axis lookup that duplicated the color channel.

**Changed — one design system.** Six palettes collapsed into one module with a per-axis no-duplicate-hex invariant; brand moved off the stock `#6366f1` indigo, which failed WCAG AA at 4.47:1.

**Fixed — landing page accessibility.** Six feature labels were `<div>`s and the only route to five of six panels, so keyboard users reached exactly one. Plus a static fallback for when the three.js CDN fails.

**Fixed — README told Pro buyers to run `nmem pro activate`**, which does not exist. Activation is `nmem shared activate --key NM-PRO-…`.

## Version bump
Six tracked files + OpenClaw plugin `1.16.1 → 1.17.0`. Rebuilt the plugin's committed `dist`, whose embedded version had drifted to 1.16.0, and synced its lockfile. `sync_refs.py --fix` updated the test count in five files.

## Pre-ship
Ruff, ruff format, mypy, import smoke, classifier, cognitive layer, plugin version consistency, and docs freshness all pass. Version consistency verified across all six files. Relying on CI for the full pytest run — the local `pre_ship` invocation times out on the transformers import, a known trap in this repo.

Note: 15 pre-existing failures in the OpenClaw plugin's vitest suite (MCP client spawn tests timing out at 5s) reproduce identically on `main` and are not run by CI.
