### PR TITLE
ci: stop npm publish failures from reporting as success

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,7 +194,23 @@ jobs:
         run: |
           npm ci || npm install
           npm run build
-          npm publish --access public || echo "Version already published — skipping"
+          if [ -z "$NODE_AUTH_TOKEN" ]; then
+            echo "::error::NPM_TOKEN secret is empty — set it in repo settings, then re-run this job."
+            exit 1
+          fi
+          set +e
+          OUT=$(npm publish --access public 2>&1)
+          CODE=$?
+          echo "$OUT"
+          set -e
+          if [ $CODE -ne 0 ]; then
+            if echo "$OUT" | grep -qiE "cannot publish over|EPUBLISHCONFLICT|previously published version"; then
+              echo "Version already published — skipping"
+            else
+              echo "::error::npm publish failed (exit $CODE). This is NOT an already-published skip."
+              exit $CODE
+            fi
+          fi
 
   # ── Publish npm (MCP wrapper) ─────────────────────────────────
   publish-npm-mcp:
@@ -227,7 +243,23 @@ jobs:
             fs.writeFileSync('server.json', JSON.stringify(srv, null, 2) + '\n');
           "
           echo "Publishing neural-memory-mcp@$VERSION"
-          npm publish --access public || echo "Version already published — skipping"
+          if [ -z "$NODE_AUTH_TOKEN" ]; then
+            echo "::error::NPM_TOKEN secret is empty — set it in repo settings, then re-run this job."
+            exit 1
+          fi
+          set +e
+          OUT=$(npm publish --access public 2>&1)
+          CODE=$?
+          echo "$OUT"
+          set -e
+          if [ $CODE -ne 0 ]; then
+            if echo "$OUT" | grep -qiE "cannot publish over|EPUBLISHCONFLICT|previously published version"; then
+              echo "Version already published — skipping"
+            else
+              echo "::error::npm publish failed (exit $CODE). This is NOT an already-published skip."
+              exit $CODE
+            fi
+          fi
 
   # ── Publish to ClawHub (OpenClaw skills registry) ──────────────
   publish-clawhub:


### PR DESCRIPTION
Found while verifying the v4.60.0 release actually landed everywhere it claimed to.

## The bug

Both npm jobs ended with:

```bash
npm publish --access public || echo "Version already published — skipping"
```

That `||` swallows **every** failure, not just a version conflict. In v4.60.0 both jobs failed with `npm error need auth` and both reported **green**.

## It has been broken for a while

This is not a one-release blip. `neural-memory-mcp` on npm is stranded at **4.43.0** while the project just shipped **4.60.0** — the token has been missing or expired across many releases with nothing surfacing it, because the workflow always printed a reassuring "already published" and moved on.

## What actually happened in v4.60.0

| Channel | Result |
|---|---|
| PyPI | ✅ `4.60.0` live |
| GitHub Release | ✅ published, not a draft |
| ClawHub | ✅ `OK. Published neural-memory@4.60.0` |
| npm `neuralmemory` | ❌ `need auth` — still on 1.16.1 |
| npm `neural-memory-mcp` | ❌ `need auth` — still on 4.43.0 |
| VS Code / Open VSX | ⏭️ skipped, `VSCE_PAT` / `OVSX_PAT` not set — this job at least said so honestly |

## The fix

Capture the output and only treat a genuine conflict (`cannot publish over`, `EPUBLISHCONFLICT`, `previously published version`) as a legitimate skip. Anything else fails the job. An empty `NODE_AUTH_TOKEN` is now reported directly instead of surfacing as a confusing auth error buried in npm's output.

## Action needed from you

`NPM_TOKEN` has to be set in repo secrets. Until it is, the next release **will fail loudly** at the npm step — that is the intended behaviour, and better than the silent gap we've had. Once the secret is in place, the two npm packages can be brought up to date by re-running those jobs on the `v4.60.0` tag.
