### PR TITLE
docs: document ClawHub, the OpenClaw channel the README never mentioned

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,14 @@ Add to your editor's MCP config:
 </details>
 
 <details>
-<summary><b>OpenClaw (Plugin)</b></summary>
+<summary><b>OpenClaw (Skill or Plugin)</b></summary>
+
+**Skill — one click via ClawHub.** Published on every release:
+
+[clawhub.ai/skills/neural-memory](https://clawhub.ai/skills/neural-memory)
+
+**Plugin — memory slot replacement.** Use this if you want NeuralMemory to *be*
+OpenClaw's memory provider rather than a skill it calls:
 
 ```bash
 pip install neural-memory && npm install -g neuralmemory

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "neural-memory-mcp",
   "version": "4.43.0",
-  "description": "Persistent memory for AI agents — 57 MCP tools, spreading activation recall, neuroscience-inspired consolidation. Works with Claude, GPT, Gemini.",
+  "description": "Persistent memory for AI agents — 63 MCP tools, spreading activation recall, neuroscience-inspired consolidation. Works with Claude, GPT, Gemini.",
   "type": "module",
   "mcpName": "io.github.nhadaututtheky/neural-memory",
   "bin": {


### PR DESCRIPTION
Follow-up to a correction on my v4.60.0 report — I had conflated two different artifacts.

## What I got wrong

I reported the failed npm publish as "the OpenClaw plugin didn't ship", which implied OpenClaw distribution was broken. It wasn't. **ClawHub published fine** (`OK. Published neural-memory@4.60.0`) and that is the one-click route for OpenClaw users.

## What the repo actually has

Three artifacts, three channels — and they are genuinely different things:

| Source | Channel | What it is | v4.60.0 |
|---|---|---|---|
| `integrations/neural-memory/SKILL.md` | ClawHub | OpenClaw **skill** — something the agent calls | ✅ |
| `integrations/neuralmemory/` | npm `neuralmemory` | OpenClaw **plugin** — replaces the memory *slot*, so NM becomes the memory provider | ❌ stuck 1.16.1 |
| `npm-package/` | npm `neural-memory-mcp` | `npx` runner shim for the MCP server | ❌ stuck 4.43.0 |

So the npm packages are a fast-install path, not the OpenClaw route. The npm outage is still real and still worth the fix in #201 — `neural-memory-mcp` being stranded ten-plus minor versions back is a genuine user-facing gap — but it did not break OpenClaw.

## The actual documentation gap

**The README does not mention ClawHub once.** The only link anywhere in the repo is buried in a blog post. A channel that publishes successfully on every release and is the easiest way in for OpenClaw users was invisible.

The OpenClaw section listed only the npm plugin route, presenting it as the only option. It now shows both, and says what distinguishes them.

Also fixed: `npm-package`'s description still advertised **57 MCP tools**; the count is 63.

Worth noting for anyone scripting against it — the domain is **clawhub.ai**. `clawhub.io` does not resolve.
