### PR TITLE
feature: Hermes Agent plugin integration (port of the OpenClaw plugin v1.17.0)

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,49 @@
+## Summary
+
+Adds `integrations/hermes-neuralmemory/` — a faithful Python port of the OpenClaw NeuralMemory plugin (`integrations/neuralmemory/`, v1.17.0) to the [Hermes Agent](https://github.com/NousResearch/hermes-agent) plugin API.
+
+Hermes agents currently have no NeuralMemory integration; this gives them the same brain-inspired persistent memory (neurons, synapses, fibers, spreading activation) the OpenClaw plugin provides, against the same `nmem-mcp` server and brain databases.
+
+## Architecture
+
+```
+Hermes Agent → neuralmemory plugin (Python) → MCP stdio → nmem-mcp → ~/.neuralmemory/brains/<brain>.db
+```
+
+## What's included (parity with the OpenClaw plugin)
+
+- **7 tools registered synchronously**: `nmem_remember`, `nmem_recall`, `nmem_context`, `nmem_stats`, `nmem_health` + compat shims `memory_search`, `memory_get`
+- **MCP stdio client**: JSON-RPC 2.0 newline-delimited, 10 MB buffer cap, least-privilege env allowlist (identical key set), 30s request / 90s init timeouts, auto-reconnect on first tool call, thread-safe (Hermes is multi-threaded)
+- **Singleton client** per (pythonPath, brain) via Hermes' official `lazy_singleton` helper
+- **Schema normalization**: identical algorithm (strip constraint keywords, integer→number, `additionalProperties: false`, ensure `properties`)
+- **Hooks**:
+  - `pre_llm_call` ← `before_prompt_build` (tool instructions on session first turn + auto-recall context every turn)
+  - `post_llm_call` ← `agent_end` (auto-capture: last 5 assistant messages, sanitized, `nmem_auto`)
+  - `on_session_reset` ← `before_reset` (boundary flush)
+- **Prompt hygiene**: `stripPromptMetadata` and `sanitizeAutoCapture` regex pipelines ported with identical passes and order
+- **Config**: same keys/defaults/validation ranges (`pythonPath`, `brain`, `autoContext`, `autoCapture`, `autoFlush`, `autoConsolidate`, `contextDepth` 0–3, `maxContextTokens` 100–10000, `timeout` 5s–120s, `initTimeout` 10s–300s), read from `plugins.entries.neuralmemory.config`
+
+## Documented adaptations (Hermes API differences)
+
+| OpenClaw | Hermes port | Why |
+|---|---|---|
+| `before_prompt_build` systemPrompt | `pre_llm_call` user-message injection, first turn only | Hermes injects into the user message to preserve prompt caching |
+| `before_compaction` flush | dropped | no Hermes plugin-hook equivalent |
+| `gateway_start` consolidation | dropped (cron workaround documented) | no Hermes plugin-hook equivalent |
+| dynamic tool registration | discovery logged, 7 stable tools registered | Hermes freezes the tool list after `register()` (same constraint as OpenClaw) |
+
+## Verification performed
+
+- `py_compile` clean on all modules
+- Load test: 7 tools + 3 hooks registered via mock context
+- **Live Hermes run** (`HERMES_PLUGINS_DEBUG=1 hermes chat`): plugin discovered, loaded, registered all 7 tools + 3 hooks from real config
+- **E2E MCP round-trip**: connect → `tools/list` (63 tools discovered) → `nmem_remember` (fiber_id returned) → `nmem_recall` (memory retrieved) → `nmem_stats`
+- Hook unit checks: both regex pipelines produce exact expected outputs; first-turn/later-turn injection paths verified
+- Mechanical parity audit vs the TypeScript source: all checks pass
+
+## Install (from plugin README)
+
+1. `pip install neural-memory` (Python 3.11+)
+2. Copy `integrations/hermes-neuralmemory/` → `~/.hermes/plugins/neuralmemory/`
+3. Enable in `config.yaml`: `plugins.enabled: [neuralmemory]` + optional `plugins.entries.neuralmemory.config`
+4. Restart Hermes

--- a/integrations/hermes-neuralmemory/README.md
+++ b/integrations/hermes-neuralmemory/README.md
@@ -1,0 +1,91 @@
+# NeuralMemory — Hermes Plugin
+
+Faithful port of the [OpenClaw NeuralMemory plugin](https://github.com/nhadaututtheky/neural-memory/tree/main/integrations/neuralmemory) (v1.17.0, TypeScript) to the Hermes plugin API (Python).
+
+Brain-inspired persistent memory for AI agents: neurons, synapses, fibers,
+spreading-activation recall, Hebbian learning, memory decay, contradiction
+detection — zero LLM dependency.
+
+```
+Hermes Agent
+    |
+    v
+NeuralMemory Plugin (this package)
+    |  Spawns + manages lifecycle
+    v
+nmem-mcp (Python MCP server, stdio transport)
+    |
+    v
+~/.neuralmemory/brains/<brain>.db (SQLite)
+```
+
+## Prerequisites
+
+```bash
+pip install neural-memory   # Python 3.11+
+nmem-mcp --help             # verify
+```
+
+## Install
+
+1. Copy this directory to `~/.hermes/plugins/neuralmemory/`
+   (on this machine: `G:\hermes\profiles\<profile>\plugins\neuralmemory\`).
+2. Enable it in `config.yaml` (Hermes user plugins are opt-in):
+
+```yaml
+plugins:
+  enabled:
+    - neuralmemory
+  entries:
+    neuralmemory:
+      config:
+        pythonPath: "python"     # Windows default — NOT python3
+        brain: "default"
+        autoContext: true
+        autoCapture: true
+        autoFlush: true
+        autoConsolidate: true
+        contextDepth: 1
+        maxContextTokens: 500
+        timeout: 30000
+        initTimeout: 90000
+```
+
+3. Restart Hermes. The 7 tools (`nmem_remember`, `nmem_recall`,
+   `nmem_context`, `nmem_stats`, `nmem_health`, `memory_search`,
+   `memory_get`) appear immediately; the MCP process connects in the
+   background and tools auto-reconnect on first call.
+
+## Port parity with the OpenClaw plugin
+
+| OpenClaw feature | Hermes port |
+|---|---|
+| 5 fallback tools + 2 compat shims (sync registration) | identical — registered via `ctx.register_tool` |
+| MCP stdio client (JSON-RPC, newline-delimited, 10 MB buffer cap, env allowlist, 30s/90s timeouts) | identical (`mcp_client.py`) |
+| Singleton client per (pythonPath, brain) | `plugins.plugin_utils.lazy_singleton` |
+| Schema normalization (strip constraint keys, integer→number, additionalProperties:false) | identical (`tools_proxy.py`) |
+| `before_prompt_build` → systemPrompt + prependContext | `pre_llm_call` — tool instructions on first turn of each session; recall context every turn. Hermes injects into the user message to preserve prompt cache |
+| `agent_end` → auto-capture (last 5 assistant msgs, sanitize, nmem_auto) | `post_llm_call` (fires on successful turns only — same guard) |
+| `before_reset` → boundary flush | `on_session_reset` |
+| `before_compaction` → emergency flush | no Hermes plugin-hook equivalent — dropped (documented) |
+| `gateway_start` → consolidation | no Hermes plugin-hook equivalent — dropped (documented; run `nmem_consolidate` manually or via cron) |
+| `stripPromptMetadata` / `sanitizeAutoCapture` regex pipelines | identical, same pass order |
+| Config validation (brain name regex, depth/tokens/timeouts ranges) | identical |
+
+### Known adaptation notes
+
+- **Dynamic tool discovery**: Hermes freezes the tool list after
+  `register()` returns (same as OpenClaw). The plugin connects in a
+  background thread, runs `tools/list`, and LOGS the full discovered tool
+  count. The 7 sync-registered tools auto-reconnect and proxy to MCP, so
+  core memory works even before the background connect completes.
+- **Auto-consolidation**: Hermes has no gateway-startup plugin hook; use a
+  Hermes cron job calling `nmem_consolidate` if you want the upstream
+  startup-consolidation behavior.
+
+## Troubleshooting
+
+- `"python" not found` → set `pythonPath` in the plugin config entry.
+- `MCP initialize failed` → verify `python -m neural_memory.mcp` works
+  manually; check `~/.hermes/logs/` for `[mcp stderr]` lines.
+- Slow cold start → raise `initTimeout` (max 300000).

--- a/integrations/hermes-neuralmemory/SPEC.md
+++ b/integrations/hermes-neuralmemory/SPEC.md
@@ -1,0 +1,66 @@
+---
+title: "NeuralMemory Hermes Plugin Port"
+status: in-progress
+created: 2026-08-06
+updated: 2026-08-06
+workflow: /build
+scope: standard
+---
+
+# Spec: NeuralMemory OpenClaw Plugin → Hermes Port
+
+## Source of truth (canon)
+Upstream: https://github.com/nhadaututtheky/neural-memory — `integrations/neuralmemory/` (v1.17.0, TypeScript, OpenClaw).
+Reference copy lives alongside this plugin at `../neuralmemory/` in this repo.
+
+## Principle
+FAITHFUL PORT, not rewrite. Every function, regex, default, and hook behavior maps 1:1 to the
+OpenClaw source unless Hermes forces an adaptation. Adaptations are listed and justified below.
+
+## Feature parity table (canon → port)
+
+| # | OpenClaw feature | Hermes equivalent | Status |
+|---|---|---|---|
+| 1 | 5 fallback tools (nmem_remember/recall/context/stats/health) | `ctx.register_tool` | PORT 1:1 |
+| 2 | 2 compat shims (memory_search, memory_get) | `ctx.register_tool` | PORT 1:1 |
+| 3 | Dynamic tool discovery via `tools/list` | Discovered tools LOGGED (Hermes freezes tool list at register()) | ADAPTED |
+| 4 | MCP stdio client (JSON-RPC, newline-delimited, 10MB buffer cap, env allowlist, timeouts 30s/90s) | `subprocess.Popen` + threading lock | PORT 1:1 |
+| 5 | Singleton client pool keyed by (pythonPath, brain) | `plugins.plugin_utils.lazy_singleton` | PORT 1:1 |
+| 6 | Schema normalization (strip constraint keys, integer→number, additionalProperties:false, ensure properties) | same algorithm | PORT 1:1 |
+| 7 | `before_prompt_build` → systemPrompt (tool instructions) | `pre_llm_call` injection — Hermes injects into USER message to preserve prompt cache | ADAPTED (documented) |
+| 8 | `before_prompt_build` → prependContext (auto-recall) | `pre_llm_call` `{"context": ...}` | PORT 1:1 |
+| 9 | `agent_end` → auto-capture (last 5 assistant msgs, sanitize, nmem_auto) | `post_llm_call` (fires on success only) | PORT 1:1 |
+| 10 | `before_compaction` → emergency flush | NO EQUIVALENT in Hermes VALID_HOOKS | DROPPED (documented) |
+| 11 | `before_reset` → session boundary flush | `on_session_reset` | PORT 1:1 |
+| 12 | `gateway_start` → consolidation (nmem_consolidate enrich) | NO EQUIVALENT hook in plugin API | DROPPED (documented; users can run nmem_consolidate manually) |
+| 13 | `stripPromptMetadata` (7 regex passes) | same regexes | PORT 1:1 |
+| 14 | `sanitizeAutoCapture` | same regexes | PORT 1:1 |
+| 15 | Config validation (brain name regex, ranges for depth/tokens/timeouts) | same validators | PORT 1:1 |
+
+## Hermes contract facts (verified in source)
+- Manifest: `plugin.yaml` with `name`, `version`, `description`, `provides_tools`, `provides_hooks`
+- Entry: `__init__.py` with `register(ctx)` (sync)
+- Tool handler signature: `handler(params, **kwargs)` → JSON string
+- Hook signatures: `pre_llm_call(session_id, user_message, conversation_history, is_first_turn, model, platform, **kwargs)` → `{"context": str}` | None; `post_llm_call(session_id, user_message, assistant_response, conversation_history, model, platform, **kwargs)` → ignored
+- Thread safety: `plugins.plugin_utils.lazy_singleton` (Hermes is multi-threaded)
+- Plugin config: `plugins.entries.neuralmemory` in config.yaml, read via `hermes_cli.config.load_config()`
+- Opt-in: `plugins.enabled: [neuralmemory]` in config.yaml
+- MCP child env: ALLOWED_ENV_KEYS allowlist ported verbatim (least privilege)
+
+## Files
+```
+neuralmemory-hermes/
+├── plugin.yaml          # manifest
+├── __init__.py          # register(ctx): tools + hooks
+├── mcp_client.py        # NeuralMemoryMcpClient (port of mcp-client.ts)
+├── tools_proxy.py       # schemas, normalization, fallback/compat tools (port of tools.ts)
+├── hooks.py             # stripPromptMetadata, sanitizeAutoCapture, hook callbacks (port of index.ts)
+├── config.py            # resolveConfig + defaults (port of index.ts config section)
+├── openclaw-src/        # READ-ONLY reference (do not ship)
+└── SPEC.md / PLAN.md
+```
+
+## Non-goals
+- No MemoryProvider subclass (separate exclusive-slot path; would replace Hermes' built-in memory entirely — different blast radius; not what canon does)
+- No from-scratch features
+- No changes to upstream repo

--- a/integrations/hermes-neuralmemory/SPEC.md
+++ b/integrations/hermes-neuralmemory/SPEC.md
@@ -11,7 +11,7 @@ scope: standard
 
 ## Source of truth (canon)
 Upstream: https://github.com/nhadaututtheky/neural-memory — `integrations/neuralmemory/` (v1.17.0, TypeScript, OpenClaw).
-Reference copy lives alongside this plugin at `../neuralmemory/` in this repo.
+Local reference copy: `openclaw-src/` in this workspace.
 
 ## Principle
 FAITHFUL PORT, not rewrite. Every function, regex, default, and hook behavior maps 1:1 to the
@@ -34,8 +34,10 @@ OpenClaw source unless Hermes forces an adaptation. Adaptations are listed and j
 | 11 | `before_reset` → session boundary flush | `on_session_reset` | PORT 1:1 |
 | 12 | `gateway_start` → consolidation (nmem_consolidate enrich) | NO EQUIVALENT hook in plugin API | DROPPED (documented; users can run nmem_consolidate manually) |
 | 13 | `stripPromptMetadata` (7 regex passes) | same regexes | PORT 1:1 |
-| 14 | `sanitizeAutoCapture` | same regexes | PORT 1:1 |
+| 14 | `sanitizeAutoCapture` | same regexes, incl. the stricter `\]\s` neuron-bullet variant (canon index.ts:134) | PORT 1:1 |
 | 15 | Config validation (brain name regex, ranges for depth/tokens/timeouts) | same validators | PORT 1:1 |
+| 16 | `service.stop()` → close MCP + evict pool entry | `on_session_end` hook → `mcp.close()` + pool eviction | PORT 1:1 (added after reviewer MINOR-2) |
+| 17 | `agent_end` reads only `ev.messages` | `post_llm_call` falls back to `assistant_response` kwarg when history has no assistant strings | ADAPTED (documented; Hermes guarantees the kwarg, history shape differs) |
 
 ## Hermes contract facts (verified in source)
 - Manifest: `plugin.yaml` with `name`, `version`, `description`, `provides_tools`, `provides_hooks`

--- a/integrations/hermes-neuralmemory/__init__.py
+++ b/integrations/hermes-neuralmemory/__init__.py
@@ -1,0 +1,120 @@
+"""NeuralMemory — Hermes Memory Plugin.
+
+Faithful port of the OpenClaw NeuralMemory plugin
+(integrations/neuralmemory/, v1.17.0) to the Hermes plugin API.
+
+Brain-inspired persistent memory for AI agents. Architecture:
+
+  Hermes ←→ Plugin (Python) ←→ MCP stdio ←→ NeuralMemory (Python)
+
+Port notes (full parity table in SPEC.md / README.md):
+  - 5 fallback tools + 2 compat shims registered synchronously at
+    register() time (Hermes freezes the tool list after register()).
+  - Dynamic tools/list discovery runs at startup and is LOGGED
+    (OpenClaw also freezes tools after register; same constraint).
+  - before_prompt_build  → pre_llm_call   (context injection)
+  - agent_end            → post_llm_call  (auto-capture)
+  - before_reset         → on_session_reset (boundary flush)
+  - before_compaction / gateway_start: no Hermes plugin-hook equivalent
+    (documented, dropped)
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+
+logger = logging.getLogger("hermes.plugins.neuralmemory")
+
+# Hermes plugin context object (duck-typed per the plugin contract).
+
+
+def register(ctx) -> None:
+    """Hermes plugin entry point — called once at plugin load (sync)."""
+    from .config import load_plugin_config
+    from .mcp_client import NeuralMemoryMcpClient
+    from .tools_proxy import create_compatibility_tools, create_fallback_tools, create_tools_from_mcp
+    from .hooks import (make_post_llm_hook, make_pre_llm_hook,
+                        make_session_reset_hook)
+
+    cfg = load_plugin_config()
+
+    # ── Singleton MCP client (port of getOrCreateMcpClient) ──
+    # Hermes is multi-threaded; use the official thread-safe helper when
+    # available, else a locked fallback.
+    def _build_client() -> NeuralMemoryMcpClient:
+        return NeuralMemoryMcpClient(
+            python_path=cfg.python_path,
+            brain=cfg.brain,
+            timeout=cfg.timeout,
+            init_timeout=cfg.init_timeout,
+        )
+
+    try:
+        from plugins.plugin_utils import lazy_singleton
+        get_client = lazy_singleton(_build_client)
+        mcp = get_client()
+    except Exception:  # noqa: BLE001 — plugin_utils unavailable outside Hermes core
+        mcp = _build_client()
+
+    # ── Register fallback + compat tools synchronously ─────────
+    # Port of OpenClaw's sync register() + deferred MCP connection.
+    # Fallback tools auto-reconnect MCP on first call.
+    fallback_tools = create_fallback_tools(mcp)
+    compat_tools = create_compatibility_tools(mcp)
+
+    for t in fallback_tools + compat_tools:
+        ctx.register_tool(
+            name=t["name"],
+            toolset="neuralmemory",
+            schema={"name": t["name"], "description": t["description"],
+                    "parameters": t["parameters"]},
+            handler=t["handler"],
+            description=t["description"],
+        )
+
+    logger.info(
+        "Registered %d NeuralMemory tools + %d compat shims (sync)",
+        len(fallback_tools), len(compat_tools),
+    )
+
+    # ── Background connect + dynamic tool discovery ────────────
+    # Port of service.start(): connect MCP, then log discovered tools.
+    # Daemon thread so plugin load never blocks Hermes startup.
+    def _startup() -> None:
+        try:
+            mcp.ensure_connected()
+            logger.info("NeuralMemory MCP connected at startup")
+            try:
+                dynamic = create_tools_from_mcp(mcp)
+                logger.info("NeuralMemory MCP discovered %d tools", len(dynamic))
+            except Exception as err:  # noqa: BLE001
+                logger.warning("Tool discovery failed: %s", err)
+        except Exception as err:  # noqa: BLE001
+            logger.warning("NeuralMemory MCP startup connect failed: %s "
+                           "(tools auto-reconnect on first call)", err)
+
+    threading.Thread(target=_startup, daemon=True,
+                     name="nmem-startup").start()
+
+    # ── Hooks ──────────────────────────────────────
+
+    # Tool awareness + auto-context before each turn
+    # (port of before_prompt_build → Hermes pre_llm_call)
+    ctx.register_hook("pre_llm_call", make_pre_llm_hook(mcp, cfg, fallback_tools))
+
+    # Auto-capture after successful turns
+    # (port of agent_end → Hermes post_llm_call)
+    if cfg.auto_capture:
+        ctx.register_hook("post_llm_call", make_post_llm_hook(mcp, cfg))
+
+    # Flush at session boundary (/new and /reset)
+    # (port of before_reset → Hermes on_session_reset)
+    if cfg.auto_flush:
+        ctx.register_hook("on_session_reset", make_session_reset_hook(mcp, cfg))
+
+    logger.info(
+        "NeuralMemory registered (brain: %s, autoContext: %s, autoCapture: %s, "
+        "autoFlush: %s) — MCP connects in background; tools auto-reconnect on first call",
+        cfg.brain, cfg.auto_context, cfg.auto_capture, cfg.auto_flush,
+    )

--- a/integrations/hermes-neuralmemory/__init__.py
+++ b/integrations/hermes-neuralmemory/__init__.py
@@ -32,10 +32,13 @@ logger = logging.getLogger("hermes.plugins.neuralmemory")
 def register(ctx) -> None:
     """Hermes plugin entry point — called once at plugin load (sync)."""
     from .config import load_plugin_config
+    from .hooks import make_post_llm_hook, make_pre_llm_hook, make_session_reset_hook
     from .mcp_client import NeuralMemoryMcpClient
-    from .tools_proxy import create_compatibility_tools, create_fallback_tools, create_tools_from_mcp
-    from .hooks import (make_post_llm_hook, make_pre_llm_hook,
-                        make_session_reset_hook)
+    from .tools_proxy import (
+        create_compatibility_tools,
+        create_fallback_tools,
+        create_tools_from_mcp,
+    )
 
     cfg = load_plugin_config()
 

--- a/integrations/hermes-neuralmemory/__init__.py
+++ b/integrations/hermes-neuralmemory/__init__.py
@@ -64,7 +64,12 @@ def _get_or_create_mcp_client(cfg) -> NeuralMemoryMcpClient:
 def register(ctx) -> None:
     """Hermes plugin entry point — called once at plugin load (sync)."""
     from .config import load_plugin_config
-    from .hooks import make_post_llm_hook, make_pre_llm_hook, make_session_reset_hook
+    from .hooks import (
+        make_post_llm_hook,
+        make_pre_llm_hook,
+        make_session_end_hook,
+        make_session_reset_hook,
+    )
     from .tools_proxy import (
         create_compatibility_tools,
         create_fallback_tools,
@@ -135,6 +140,11 @@ def register(ctx) -> None:
     # (port of before_reset → Hermes on_session_reset)
     if cfg.auto_flush:
         ctx.register_hook("on_session_reset", make_session_reset_hook(mcp, cfg))
+
+    # MCP process teardown at session end
+    # (port of service.stop() → Hermes on_session_end; also evicts the pool entry
+    # so a later register() builds a fresh client — reviewer MINOR-2)
+    ctx.register_hook("on_session_end", make_session_end_hook(mcp, cfg))
 
     logger.info(
         "NeuralMemory registered (brain: %s, autoContext: %s, autoCapture: %s, "

--- a/integrations/hermes-neuralmemory/__init__.py
+++ b/integrations/hermes-neuralmemory/__init__.py
@@ -23,8 +23,40 @@ from __future__ import annotations
 
 import logging
 import threading
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .mcp_client import NeuralMemoryMcpClient
 
 logger = logging.getLogger("hermes.plugins.neuralmemory")
+
+# ── Singleton MCP client pool (port of the mcpClients Map in index.ts) ──
+# Multiple register() calls share one connected client per (pythonPath, brain).
+_mcp_clients: dict[str, NeuralMemoryMcpClient] = {}
+_mcp_clients_lock = threading.Lock()
+
+
+def _get_or_create_mcp_client(cfg) -> NeuralMemoryMcpClient:
+    """Port of getOrCreateMcpClient(): keyed pool, thread-safe double-check."""
+    from .mcp_client import NeuralMemoryMcpClient
+
+    key = f"{cfg.python_path}::{cfg.brain}"
+    existing = _mcp_clients.get(key)
+    if existing is not None:
+        logger.debug('Reusing existing MCP client for brain "%s"', cfg.brain)
+        return existing
+    with _mcp_clients_lock:
+        existing = _mcp_clients.get(key)
+        if existing is not None:
+            return existing
+        client = NeuralMemoryMcpClient(
+            python_path=cfg.python_path,
+            brain=cfg.brain,
+            timeout=cfg.timeout,
+            init_timeout=cfg.init_timeout,
+        )
+        _mcp_clients[key] = client
+        return client
 
 # Hermes plugin context object (duck-typed per the plugin contract).
 
@@ -33,7 +65,6 @@ def register(ctx) -> None:
     """Hermes plugin entry point — called once at plugin load (sync)."""
     from .config import load_plugin_config
     from .hooks import make_post_llm_hook, make_pre_llm_hook, make_session_reset_hook
-    from .mcp_client import NeuralMemoryMcpClient
     from .tools_proxy import (
         create_compatibility_tools,
         create_fallback_tools,
@@ -42,23 +73,12 @@ def register(ctx) -> None:
 
     cfg = load_plugin_config()
 
-    # ── Singleton MCP client (port of getOrCreateMcpClient) ──
-    # Hermes is multi-threaded; use the official thread-safe helper when
-    # available, else a locked fallback.
-    def _build_client() -> NeuralMemoryMcpClient:
-        return NeuralMemoryMcpClient(
-            python_path=cfg.python_path,
-            brain=cfg.brain,
-            timeout=cfg.timeout,
-            init_timeout=cfg.init_timeout,
-        )
-
-    try:
-        from plugins.plugin_utils import lazy_singleton
-        get_client = lazy_singleton(_build_client)
-        mcp = get_client()
-    except Exception:  # noqa: BLE001 — plugin_utils unavailable outside Hermes core
-        mcp = _build_client()
+    # ── Singleton MCP client pool (port of getOrCreateMcpClient) ──
+    # Module-level pool keyed by (pythonPath, brain), exactly mirroring the
+    # upstream mcpClients Map. A bare lazy_singleton(_build_client) would be
+    # keyed per factory CLOSURE — a new singleton on every register() call,
+    # spawning duplicate MCP processes (reviewer finding M3).
+    mcp = _get_or_create_mcp_client(cfg)
 
     # ── Register fallback + compat tools synchronously ─────────
     # Port of OpenClaw's sync register() + deferred MCP connection.
@@ -91,9 +111,9 @@ def register(ctx) -> None:
             try:
                 dynamic = create_tools_from_mcp(mcp)
                 logger.info("NeuralMemory MCP discovered %d tools", len(dynamic))
-            except Exception as err:  # noqa: BLE001
+            except Exception as err:
                 logger.warning("Tool discovery failed: %s", err)
-        except Exception as err:  # noqa: BLE001
+        except Exception as err:
             logger.warning("NeuralMemory MCP startup connect failed: %s "
                            "(tools auto-reconnect on first call)", err)
 

--- a/integrations/hermes-neuralmemory/config.py
+++ b/integrations/hermes-neuralmemory/config.py
@@ -7,6 +7,7 @@ Values are read from Hermes config.yaml: plugins.entries.neuralmemory
 
 from __future__ import annotations
 
+import math
 import re
 from dataclasses import dataclass
 
@@ -64,7 +65,6 @@ def resolve_config(raw: dict | None) -> PluginConfig:
         v = merged.get(key)
         if isinstance(v, (int, float)) and not isinstance(v, bool):
             try:
-                import math
                 if math.isfinite(v) and lo <= v <= hi:
                     return int(v)
             except (TypeError, ValueError):

--- a/integrations/hermes-neuralmemory/config.py
+++ b/integrations/hermes-neuralmemory/config.py
@@ -105,7 +105,7 @@ def load_plugin_config() -> PluginConfig:
         entries = (cfg.get("plugins") or {}).get("entries") or {}
         entry = entries.get("neuralmemory") or {}
         raw = dict(entry.get("config") or {})
-    except Exception:  # noqa: BLE001 — fail open to defaults, never crash agent on config read
+    except Exception:
         # Fail open to defaults — a broken config read must never crash the agent.
         raw = {}
 

--- a/integrations/hermes-neuralmemory/config.py
+++ b/integrations/hermes-neuralmemory/config.py
@@ -105,7 +105,7 @@ def load_plugin_config() -> PluginConfig:
         entries = (cfg.get("plugins") or {}).get("entries") or {}
         entry = entries.get("neuralmemory") or {}
         raw = dict(entry.get("config") or {})
-    except Exception:
+    except Exception:  # noqa: BLE001 — fail open to defaults, never crash agent on config read
         # Fail open to defaults — a broken config read must never crash the agent.
         raw = {}
 

--- a/integrations/hermes-neuralmemory/config.py
+++ b/integrations/hermes-neuralmemory/config.py
@@ -1,0 +1,115 @@
+"""Plugin configuration — port of the config section of integrations/neuralmemory/src/index.ts.
+
+Faithful port: same defaults, same validation ranges, same regex.
+Values are read from Hermes config.yaml: plugins.entries.neuralmemory
+(env overrides kept for the MCP child process, matching upstream).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+BRAIN_NAME_RE = re.compile(r"^[a-zA-Z0-9_\-.]{1,64}$")
+MAX_AUTO_CAPTURE_CHARS = 50_000
+
+
+@dataclass(frozen=True)
+class PluginConfig:
+    python_path: str
+    brain: str
+    auto_context: bool
+    auto_capture: bool
+    auto_flush: bool
+    auto_consolidate: bool
+    context_depth: int
+    max_context_tokens: int
+    timeout: int
+    init_timeout: int
+
+
+DEFAULT_CONFIG = PluginConfig(
+    python_path="python",
+    brain="default",
+    auto_context=True,
+    auto_capture=True,
+    auto_flush=True,
+    auto_consolidate=True,
+    context_depth=1,
+    max_context_tokens=500,
+    timeout=30_000,
+    init_timeout=90_000,
+)
+
+
+def resolve_config(raw: dict | None) -> PluginConfig:
+    """Merge raw config dict over defaults with the same validation as upstream."""
+    merged = {**(raw or {})}
+
+    def _str(key: str, default: str) -> str:
+        v = merged.get(key)
+        return v if isinstance(v, str) and v else default
+
+    def _bool(key: str, default: bool) -> bool:
+        v = merged.get(key)
+        return v if isinstance(v, bool) else default
+
+    def _int_range(key: str, default: int, lo: int, hi: int) -> int:
+        v = merged.get(key)
+        if isinstance(v, int) and not isinstance(v, bool) and lo <= v <= hi:
+            return v
+        return default
+
+    def _num_range(key: str, default: int, lo: int, hi: int) -> int:
+        v = merged.get(key)
+        if isinstance(v, (int, float)) and not isinstance(v, bool):
+            try:
+                import math
+                if math.isfinite(v) and lo <= v <= hi:
+                    return int(v)
+            except (TypeError, ValueError):
+                pass
+        return default
+
+    brain = merged.get("brain")
+    if not (isinstance(brain, str) and BRAIN_NAME_RE.match(brain)):
+        brain = DEFAULT_CONFIG.brain
+
+    return PluginConfig(
+        python_path=_str("pythonPath", DEFAULT_CONFIG.python_path),
+        brain=brain,
+        auto_context=_bool("autoContext", DEFAULT_CONFIG.auto_context),
+        auto_capture=_bool("autoCapture", DEFAULT_CONFIG.auto_capture),
+        auto_flush=_bool("autoFlush", DEFAULT_CONFIG.auto_flush),
+        auto_consolidate=_bool("autoConsolidate", DEFAULT_CONFIG.auto_consolidate),
+        context_depth=_int_range("contextDepth", DEFAULT_CONFIG.context_depth, 0, 3),
+        max_context_tokens=_int_range("maxContextTokens", DEFAULT_CONFIG.max_context_tokens, 100, 10_000),
+        timeout=_num_range("timeout", DEFAULT_CONFIG.timeout, 5_000, 120_000),
+        init_timeout=_num_range("initTimeout", DEFAULT_CONFIG.init_timeout, 10_000, 300_000),
+    )
+
+
+def load_plugin_config() -> PluginConfig:
+    """Load config from plugins.entries.neuralmemory in Hermes config.yaml.
+
+    Falls back to env vars (NEURALMEMORY_BRAIN) then defaults — mirrors how
+    the OpenClaw plugin reads api.pluginConfig.
+    """
+    import os
+
+    raw: dict = {}
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        entries = (cfg.get("plugins") or {}).get("entries") or {}
+        entry = entries.get("neuralmemory") or {}
+        raw = dict(entry.get("config") or {})
+    except Exception:
+        # Fail open to defaults — a broken config read must never crash the agent.
+        raw = {}
+
+    if os.environ.get("NEURALMEMORY_BRAIN") and "brain" not in raw:
+        raw["brain"] = os.environ["NEURALMEMORY_BRAIN"]
+
+    return resolve_config(raw)

--- a/integrations/hermes-neuralmemory/hooks.py
+++ b/integrations/hermes-neuralmemory/hooks.py
@@ -1,0 +1,238 @@
+"""Hooks + prompt hygiene — port of the hook section of integrations/neuralmemory/src/index.ts.
+
+Faithful port: stripPromptMetadata and sanitizeAutoCapture carry the same
+regex passes in the same order with the same fallback logic. Hook wiring is
+adapted to Hermes hook names (documented in SPEC.md parity table).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any, Callable
+
+from .config import MAX_AUTO_CAPTURE_CHARS, PluginConfig
+from .mcp_client import NeuralMemoryMcpClient
+
+logger = logging.getLogger("hermes.plugins.neuralmemory")
+
+# ── Prompt metadata stripping (port of stripPromptMetadata) ──────
+#
+# Stripping order matters — later passes clean up residue from earlier ones.
+
+_RE_JSON_META = re.compile(
+    r'^\{[\s\S]*?"(?:conversation|message_id|sender_id|sender|chat_id|update_id)"[\s\S]*?\}$',
+    re.MULTILINE,
+)
+_RE_NM_SECTIONS = re.compile(
+    r'^#{1,3}\s*(?:Relevant Memories|Related Information|Relevant Context|Neural Memory)'
+    r'[\s\S]*?(?=\n#{1,3}\s|\n\n(?![-•*\s])|$)',
+    re.MULTILINE | re.IGNORECASE,
+)
+_RE_NEURON_BULLETS = re.compile(
+    r'^-\s*\[(?:concept|entity|decision|error|preference|insight|memory|fact|workflow|instruction|pattern)\].*$',
+    re.MULTILINE | re.IGNORECASE,
+)
+_RE_NM_WRAPPERS = re.compile(r'^\[NeuralMemory\s*[—–-].*\]$', re.MULTILINE)
+_RE_META_LABELS = re.compile(
+    r'^(?:Conversation info|Sender|Context|System)\s*\(.*?\)\s*:?\s*$',
+    re.MULTILINE | re.IGNORECASE,
+)
+_RE_EXPORT_LINES = re.compile(r'^export\s+\w+=.*$', re.MULTILINE)
+
+
+def strip_prompt_metadata(raw: str) -> str:
+    """Port of stripPromptMetadata() — same 7 passes, same fallback."""
+    cleaned = raw
+
+    # 1. Remove JSON blocks (Telegram metadata, conversation info)
+    cleaned = _RE_JSON_META.sub("", cleaned)
+    # 2. Remove NeuralMemory context sections (## Relevant Memories, etc.)
+    #    The |$ ensures sections at end-of-string are also stripped.
+    cleaned = _RE_NM_SECTIONS.sub("", cleaned)
+    # 3. Remove neuron-type bullet lines injected by NM context
+    cleaned = _RE_NEURON_BULLETS.sub("", cleaned)
+    # 4. Remove [NeuralMemory — ...] wrapper lines
+    cleaned = _RE_NM_WRAPPERS.sub("", cleaned)
+    # 5. Remove metadata labels (untrusted metadata lines)
+    cleaned = _RE_META_LABELS.sub("", cleaned)
+    # 6. Remove env/export lines
+    cleaned = _RE_EXPORT_LINES.sub("", cleaned)
+    # 7. Collapse whitespace runs
+    cleaned = re.sub(r'\n{3,}', '\n\n', cleaned).strip()
+
+    # Fallback: if everything was stripped, use last non-empty line of raw
+    if not cleaned:
+        lines = [line for line in raw.split("\n") if line.strip()]
+        cleaned = lines[-1].strip() if lines else raw.strip()
+
+    return cleaned
+
+
+# ── Auto-capture sanitization (port of sanitizeAutoCapture) ──────
+
+_RE_NM_SECTION_HEADERS = re.compile(
+    r'^#{1,3}\s*(?:Relevant Memories|Related Information|Relevant Context|Neural Memory)\b.*$',
+    re.MULTILINE | re.IGNORECASE,
+)
+_RE_ACK_LINES = re.compile(
+    r'^(?:OK|Sure|Done|Got it|Understood|Noted|Alright|I see|Thanks|Thank you|Okay)\.?\s*$',
+    re.MULTILINE | re.IGNORECASE,
+)
+
+
+def sanitize_auto_capture(raw: str) -> str:
+    """Port of sanitizeAutoCapture() — defense-in-depth before nmem_auto."""
+    cleaned = raw
+
+    # Strip NM context section headers
+    cleaned = _RE_NM_SECTION_HEADERS.sub("", cleaned)
+    # Strip [NeuralMemory — ...] wrapper lines
+    cleaned = _RE_NM_WRAPPERS.sub("", cleaned)
+    # Strip neuron-type bullet lines (- [concept] ..., - [error] ...)
+    cleaned = _RE_NEURON_BULLETS.sub("", cleaned)
+    # Strip metadata labels
+    cleaned = re.sub(
+        r'^(?:Conversation info|Sender|Context)\s*\(.*?\)\s*:?\s*$',
+        "", cleaned, flags=re.MULTILINE | re.IGNORECASE,
+    )
+    # Strip short acknowledgement lines (< 20 chars, common filler)
+    cleaned = _RE_ACK_LINES.sub("", cleaned)
+    # Collapse whitespace
+    cleaned = re.sub(r'\n{3,}', '\n\n', cleaned).strip()
+
+    return cleaned
+
+
+# ── Tool awareness block (port of buildToolInstructions) ─────────
+
+def build_tool_instructions(tools: list[dict]) -> str:
+    """Port of buildToolInstructions() — tool list built from registered tools."""
+    tool_list = "\n".join(
+        f"- {t['name']}: {t['description'][:100]}" for t in tools
+    )
+
+    return (
+        "Neural Memory gives you persistent memory across sessions. Use it proactively — "
+        "each session starts fresh, so without explicit saves ALL discoveries are lost.\n\n"
+        "These are TOOL CALLS, not CLI commands. Do NOT run \"nmem remember\" in terminal.\n\n"
+        "## Available Tools\n"
+        f"{tool_list}\n\n"
+        "nmem_* is your primary memory system. memory_search/memory_get are legacy aliases for nmem_recall.\n\n"
+        "## WHEN TO RECALL\n"
+        "- New session starts → nmem_recall(\"current project context\")\n"
+        "- User references past event → nmem_recall(\"<that topic>\")\n"
+        "- Prefix queries with project name for precision\n\n"
+        "## WHEN TO SAVE\n"
+        "After each task: did you make a decision (type=\"decision\", priority=7), fix a bug "
+        "(type=\"error\", priority=7), learn a preference (type=\"preference\", priority=8), "
+        "or discover an insight (type=\"insight\", priority=6)?\n\n"
+        "Save with: nmem_remember(content=\"Chose X over Y because Z\", type=\"decision\", "
+        "priority=7, tags=[\"project\", \"topic\"])\n\n"
+        "## CONTENT QUALITY\n"
+        "- Max 1-3 sentences. Use causal language: \"Chose X because Y\", \"Root cause was X, fixed by Y\".\n"
+        "- Always include project name + topic in tags (lowercase).\n"
+        "- For temporary scratch notes: nmem_remember(content=\"...\", ephemeral=true) — auto-expires, never synced.\n\n"
+        "## SESSION END\n"
+        "nmem_auto(action=\"process\", text=\"<brief session summary>\")\n\n"
+        "## COMPACT MODE\n"
+        "All tools support compact=true (saves 60-80% tokens) and token_budget=N."
+    )
+
+
+# ── Hook factories ──────────────────────────────
+
+def make_pre_llm_hook(mcp: NeuralMemoryMcpClient, cfg: PluginConfig,
+                      tools: list[dict]) -> Callable[..., Any]:
+    """Port of the before_prompt_build hook.
+
+    Adaptation (SPEC.md row 7): OpenClaw appends tool instructions to the
+    SYSTEM prompt on every prompt build; Hermes pre_llm_call injects into the
+    USER message (prompt-cache preserving). Instructions are therefore
+    injected on the first turn of each session only (same intent: fresh
+    session awareness, survives /new), and auto-recall context on every turn.
+    """
+    instructions = build_tool_instructions(tools)
+
+    def hook(session_id: str = "", user_message: str = "",
+             conversation_history: list | None = None,
+             is_first_turn: bool = False, model: str = "", platform: str = "",
+             **kwargs: Any) -> dict | None:
+        parts: list[str] = []
+
+        if is_first_turn:
+            parts.append(instructions)
+
+        if cfg.auto_context and mcp.connected:
+            try:
+                query = strip_prompt_metadata(user_message)
+                raw = mcp.call_tool("nmem_recall", {
+                    "query": query,
+                    "depth": cfg.context_depth,
+                    "max_tokens": cfg.max_context_tokens,
+                    "clean_for_prompt": True,
+                })
+                data = json.loads(raw) if raw else {}
+                if isinstance(data, dict) and data.get("answer") and (data.get("confidence") or 0) > 0.1:
+                    parts.append(f"[NeuralMemory — relevant context]\n{data['answer']}")
+            except Exception as err:  # noqa: BLE001 — recall must never break a turn
+                logger.warning("Auto-context failed: %s", err)
+
+        if not parts:
+            return None
+        return {"context": "\n\n".join(parts)}
+
+    return hook
+
+
+def make_post_llm_hook(mcp: NeuralMemoryMcpClient,
+                       cfg: PluginConfig) -> Callable[..., None]:
+    """Port of the agent_end hook → Hermes post_llm_call.
+
+    post_llm_call fires only on successful turns (documented: does not fire
+    on interruption), matching the upstream `if (!ev.success) return` guard.
+    """
+
+    def hook(session_id: str = "", user_message: str = "",
+             assistant_response: str = "", conversation_history: list | None = None,
+             model: str = "", platform: str = "", **kwargs: Any) -> None:
+        if not mcp.connected:
+            return
+        try:
+            # Last 5 messages, assistant-role string contents only (upstream behavior)
+            messages = (conversation_history or [])[-5:]
+            contents: list[str] = []
+            for m in messages:
+                if isinstance(m, dict) and m.get("role") == "assistant" \
+                        and isinstance(m.get("content"), str):
+                    contents.append(m["content"])
+            if not contents and assistant_response:
+                contents = [assistant_response]
+            raw_text = "\n".join(contents)[:MAX_AUTO_CAPTURE_CHARS]
+
+            # Strip NM context noise and short acknowledgements before re-ingest
+            text = sanitize_auto_capture(raw_text)
+
+            if len(text) > 50:
+                mcp.call_tool("nmem_auto", {"action": "process", "text": text})
+        except Exception as err:  # noqa: BLE001
+            logger.warning("Auto-capture failed: %s", err)
+
+    return hook
+
+
+def make_session_reset_hook(mcp: NeuralMemoryMcpClient,
+                           cfg: PluginConfig) -> Callable[..., None]:
+    """Port of the before_reset hook → Hermes on_session_reset (flush at session boundary)."""
+
+    def hook(**kwargs: Any) -> None:
+        if not mcp.connected:
+            return
+        try:
+            mcp.call_tool("nmem_auto", {"action": "process",
+                                        "text": "[session boundary — reset]"})
+        except Exception as err:  # noqa: BLE001
+            logger.warning("Session boundary flush failed: %s", err)
+
+    return hook

--- a/integrations/hermes-neuralmemory/hooks.py
+++ b/integrations/hermes-neuralmemory/hooks.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 import json
 import logging
 import re
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 from .config import MAX_AUTO_CAPTURE_CHARS, PluginConfig
 from .mcp_client import NeuralMemoryMcpClient

--- a/integrations/hermes-neuralmemory/hooks.py
+++ b/integrations/hermes-neuralmemory/hooks.py
@@ -35,6 +35,13 @@ _RE_NEURON_BULLETS = re.compile(
     r'^-\s*\[(?:concept|entity|decision|error|preference|insight|memory|fact|workflow|instruction|pattern)\].*$',
     re.MULTILINE | re.IGNORECASE,
 )
+# sanitizeAutoCapture variant (canon index.ts:134): requires whitespace after the
+# bracket — stricter than the stripPromptMetadata variant above. Do NOT merge these
+# two; they are intentionally different in canon (reviewer MINOR-3).
+_RE_NEURON_BULLETS_WS = re.compile(
+    r'^-\s*\[(?:concept|entity|decision|error|preference|insight|memory|fact|workflow|instruction|pattern)\]\s.*$',
+    re.MULTILINE | re.IGNORECASE,
+)
 _RE_NM_WRAPPERS = re.compile(r'^\[NeuralMemory\s*[—–-].*\]$', re.MULTILINE)  # noqa: RUF001 — em/en dashes are parity-critical: they match upstream's own "[NeuralMemory — …]" wrapper format
 _RE_META_LABELS = re.compile(
     r'^(?:Conversation info|Sender|Context|System)\s*\(.*?\)\s*:?\s*$',
@@ -92,7 +99,8 @@ def sanitize_auto_capture(raw: str) -> str:
     # Strip [NeuralMemory — ...] wrapper lines
     cleaned = _RE_NM_WRAPPERS.sub("", cleaned)
     # Strip neuron-type bullet lines (- [concept] ..., - [error] ...)
-    cleaned = _RE_NEURON_BULLETS.sub("", cleaned)
+    # Canon uses the stricter whitespace-required variant here (index.ts:134).
+    cleaned = _RE_NEURON_BULLETS_WS.sub("", cleaned)
     # Strip metadata labels
     cleaned = re.sub(
         r'^(?:Conversation info|Sender|Context)\s*\(.*?\)\s*:?\s*$',
@@ -233,7 +241,30 @@ def make_session_reset_hook(mcp: NeuralMemoryMcpClient,
         try:
             mcp.call_tool("nmem_auto", {"action": "process",
                                         "text": "[session boundary — reset]"})
-        except Exception as err:
+        except Exception as err:  # noqa: BLE001
             logger.warning("Session boundary flush failed: %s", err)
+
+    return hook
+
+
+def make_session_end_hook(mcp: NeuralMemoryMcpClient,
+                          cfg: PluginConfig) -> Callable[..., None]:
+    """Port of service.stop() → Hermes on_session_end.
+
+    Canon stop() closes the MCP process and evicts the pool entry so the next
+    register() creates a fresh client (index.ts:382-388).
+    """
+
+    def hook(**kwargs: Any) -> None:
+        try:
+            from . import _mcp_clients
+            _mcp_clients.pop(f"{cfg.python_path}::{cfg.brain}", None)
+        except Exception:  # noqa: BLE001 — eviction is best-effort
+            pass
+        try:
+            mcp.close()
+        except Exception as err:  # noqa: BLE001
+            logger.warning("MCP close on session end failed: %s", err)
+        logger.info("NeuralMemory MCP service stopped (session end)")
 
     return hook

--- a/integrations/hermes-neuralmemory/hooks.py
+++ b/integrations/hermes-neuralmemory/hooks.py
@@ -35,7 +35,7 @@ _RE_NEURON_BULLETS = re.compile(
     r'^-\s*\[(?:concept|entity|decision|error|preference|insight|memory|fact|workflow|instruction|pattern)\].*$',
     re.MULTILINE | re.IGNORECASE,
 )
-_RE_NM_WRAPPERS = re.compile(r'^\[NeuralMemory\s*[—–-].*\]$', re.MULTILINE)
+_RE_NM_WRAPPERS = re.compile(r'^\[NeuralMemory\s*[—–-].*\]$', re.MULTILINE)  # noqa: RUF001 — em/en dashes are parity-critical: they match upstream's own "[NeuralMemory — …]" wrapper format
 _RE_META_LABELS = re.compile(
     r'^(?:Conversation info|Sender|Context|System)\s*\(.*?\)\s*:?\s*$',
     re.MULTILINE | re.IGNORECASE,
@@ -177,7 +177,7 @@ def make_pre_llm_hook(mcp: NeuralMemoryMcpClient, cfg: PluginConfig,
                 data = json.loads(raw) if raw else {}
                 if isinstance(data, dict) and data.get("answer") and (data.get("confidence") or 0) > 0.1:
                     parts.append(f"[NeuralMemory — relevant context]\n{data['answer']}")
-            except Exception as err:  # noqa: BLE001 — recall must never break a turn
+            except Exception as err:
                 logger.warning("Auto-context failed: %s", err)
 
         if not parts:
@@ -217,7 +217,7 @@ def make_post_llm_hook(mcp: NeuralMemoryMcpClient,
 
             if len(text) > 50:
                 mcp.call_tool("nmem_auto", {"action": "process", "text": text})
-        except Exception as err:  # noqa: BLE001
+        except Exception as err:
             logger.warning("Auto-capture failed: %s", err)
 
     return hook
@@ -233,7 +233,7 @@ def make_session_reset_hook(mcp: NeuralMemoryMcpClient,
         try:
             mcp.call_tool("nmem_auto", {"action": "process",
                                         "text": "[session boundary — reset]"})
-        except Exception as err:  # noqa: BLE001
+        except Exception as err:
             logger.warning("Session boundary flush failed: %s", err)
 
     return hook

--- a/integrations/hermes-neuralmemory/mcp_client.py
+++ b/integrations/hermes-neuralmemory/mcp_client.py
@@ -137,7 +137,10 @@ class NeuralMemoryMcpClient:
     def connect(self) -> None:
         """Spawn the MCP process and complete the initialize handshake. Port of connect()."""
         env = build_child_env(self._brain)
+        # Generation-scoped stderr capture (reviewer M3-5): a previous generation's
+        # stderr thread must never append into the new generation's diagnostics.
         self._stderr_lines: list[str] = []
+        stderr_lines = self._stderr_lines
 
         try:
             self._proc = subprocess.Popen(  # noqa: S603 — pythonPath comes from validated plugin config; args are static
@@ -157,7 +160,7 @@ class NeuralMemoryMcpClient:
         # Reader threads for stdout (JSON-RPC) and stderr (diagnostics)
         threading.Thread(target=self._read_stdout, daemon=True,
                          name="nmem-mcp-stdout").start()
-        threading.Thread(target=self._read_stderr, daemon=True,
+        threading.Thread(target=self._read_stderr, args=(stderr_lines,), daemon=True,
                          name="nmem-mcp-stderr").start()
         threading.Thread(target=self._wait_exit, daemon=True,
                          name="nmem-mcp-exit").start()
@@ -170,7 +173,10 @@ class NeuralMemoryMcpClient:
                 "clientInfo": {"name": CLIENT_NAME, "version": CLIENT_VERSION},
             }, timeout_override=self._init_timeout)
         except Exception as err:
-            stderr = "\n".join(self._stderr_lines)
+            # Reviewer M2: tear down the failed generation — a hung child and its
+            # reader threads must not leak, and a later retry must not orphan it.
+            self._teardown_failed_connect()
+            stderr = "\n".join(stderr_lines)
             detail = (f"\nPython stderr:\n{stderr}" if stderr
                       else "\nNo stderr output — the Python process may have hung.")
             raise RuntimeError(
@@ -216,9 +222,28 @@ class NeuralMemoryMcpClient:
                     proc.wait(timeout=3)
                 except subprocess.TimeoutExpired:
                     proc.kill()
-            except Exception:
+            except Exception:  # noqa: BLE001, S110 — best-effort teardown
                 pass
         logger.info("MCP client closed")
+
+    def _teardown_failed_connect(self) -> None:
+        """Kill a child whose handshake failed (reviewer M2).
+
+        Popen succeeded but initialize failed/timed out — without this the
+        hung child and its reader threads leak, and a later ensure_connected
+        retry would overwrite self._proc and orphan the first process.
+        """
+        self._reject_all(RuntimeError("MCP initialize failed — connect aborted"))
+        proc, self._proc = self._proc, None
+        if proc is not None:
+            try:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=3)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+            except Exception:  # noqa: BLE001, S110 — best-effort teardown
+                pass
 
     # ── JSON-RPC protocol layer ──────────────────────────
 
@@ -294,15 +319,15 @@ class NeuralMemoryMcpClient:
             self._handle_line(line)
         return raw_buffer
 
-    def _read_stderr(self) -> None:
+    def _read_stderr(self, stderr_lines: list[str]) -> None:
         proc = self._proc
         if proc is None or proc.stderr is None:
             return
         for raw in iter(proc.stderr.readline, b""):
             msg = raw.decode("utf-8", errors="replace").strip()
             if msg:
-                if len(self._stderr_lines) < MAX_STDERR_LINES:
-                    self._stderr_lines.append(msg)
+                if len(stderr_lines) < MAX_STDERR_LINES:
+                    stderr_lines.append(msg)
                 logger.warning("[mcp stderr] %s", msg)
 
     def _wait_exit(self) -> None:

--- a/integrations/hermes-neuralmemory/mcp_client.py
+++ b/integrations/hermes-neuralmemory/mcp_client.py
@@ -140,7 +140,7 @@ class NeuralMemoryMcpClient:
         self._stderr_lines: list[str] = []
 
         try:
-            self._proc = subprocess.Popen(
+            self._proc = subprocess.Popen(  # noqa: S603 — pythonPath comes from validated plugin config; args are static
                 [self._python_path, "-m", "neural_memory.mcp"],
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
@@ -216,7 +216,7 @@ class NeuralMemoryMcpClient:
                     proc.wait(timeout=3)
                 except subprocess.TimeoutExpired:
                     proc.kill()
-            except Exception:  # noqa: BLE001, S110 — best-effort teardown
+            except Exception:
                 pass
         logger.info("MCP client closed")
 
@@ -258,7 +258,7 @@ class NeuralMemoryMcpClient:
             try:
                 proc.stdin.write(frame)
                 proc.stdin.flush()
-            except (BrokenPipeError, OSError, ValueError):  # noqa: S110 — dead-pipe writes are expected after process exit
+            except (BrokenPipeError, OSError, ValueError):
                 pass
 
     # ── Reader threads ───────────────────────────────
@@ -267,17 +267,32 @@ class NeuralMemoryMcpClient:
         proc = self._proc
         if proc is None or proc.stdout is None:
             return
-        buffered = 0
-        for line in iter(proc.stdout.readline, b""):
-            buffered += len(line)
-            if buffered > MAX_BUFFER_BYTES:
+        stdout = proc.stdout
+        # Port of mcp-client.ts drainBuffer(): cap the UNDRAINED buffer only.
+        # Consumed bytes are removed as lines are processed, so a long-lived
+        # connection never trips the cap on well-formed traffic.
+        raw_buffer = b""
+        for chunk in iter(lambda: stdout.read(65536), b""):
+            raw_buffer += chunk
+            if len(raw_buffer) > MAX_BUFFER_BYTES:
                 logger.error("MCP buffer exceeded %d bytes — killing process", MAX_BUFFER_BYTES)
                 try:
                     proc.kill()
-                except Exception:  # noqa: BLE001
+                except Exception:
                     pass
                 return
+            raw_buffer = self._drain_buffer(raw_buffer)
+
+    def _drain_buffer(self, raw_buffer: bytes) -> bytes:
+        """Parse complete newline-delimited messages; return the undrained remainder."""
+        while True:
+            newline_index = raw_buffer.find(b"\n")
+            if newline_index == -1:
+                break
+            line = raw_buffer[:newline_index]
+            raw_buffer = raw_buffer[newline_index + 1:]
             self._handle_line(line)
+        return raw_buffer
 
     def _read_stderr(self) -> None:
         proc = self._proc

--- a/integrations/hermes-neuralmemory/mcp_client.py
+++ b/integrations/hermes-neuralmemory/mcp_client.py
@@ -1,0 +1,336 @@
+"""NeuralMemory MCP client — port of integrations/neuralmemory/src/mcp-client.ts.
+
+JSON-RPC 2.0 over stdio, newline-delimited JSON Lines. Spawns
+`python -m neural_memory.mcp` and manages its lifecycle.
+
+Faithful port: same protocol constants, same env allowlist, same buffer
+cap, same timeout defaults, same error messages.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import threading
+import time
+from typing import Any, Callable
+
+logger = logging.getLogger("hermes.plugins.neuralmemory")
+
+# ── Constants (ported verbatim from mcp-client.ts) ────────────
+
+PROTOCOL_VERSION = "2024-11-05"
+DEFAULT_TIMEOUT = 30_000  # ms
+CLIENT_NAME = "hermes-neuralmemory"
+CLIENT_VERSION = "1.0.0"
+MAX_BUFFER_BYTES = 10 * 1024 * 1024  # 10 MB safety cap
+MAX_STDERR_LINES = 50
+
+# Env vars forwarded to the MCP child process (least-privilege).
+ALLOWED_ENV_KEYS: frozenset[str] = frozenset([
+    "PATH",
+    "PATHEXT",
+    "HOME",
+    "USERPROFILE",
+    "SYSTEMROOT",
+    "TEMP",
+    "TMP",
+    "LANG",
+    "LC_ALL",
+    "VIRTUAL_ENV",
+    "CONDA_PREFIX",
+    "PYTHONPATH",
+    "PYTHONHOME",
+    "NEURALMEMORY_DIR",
+    "NEURALMEMORY_BRAIN",
+    "NEURAL_MEMORY_DIR",
+    "NEURAL_MEMORY_JSON",
+    "NEURAL_MEMORY_DEBUG",
+])
+
+
+def build_child_env(brain: str) -> dict[str, str]:
+    """Build a minimal env for the child process (least-privilege). Port of buildChildEnv."""
+    env: dict[str, str] = {}
+    for key in ALLOWED_ENV_KEYS:
+        value = os.environ.get(key)
+        if value is not None:
+            env[key] = value
+    if brain != "default":
+        env["NEURALMEMORY_BRAIN"] = brain
+    return env
+
+
+class _Pending:
+    __slots__ = ("event", "result", "error")
+
+    def __init__(self) -> None:
+        self.event = threading.Event()
+        self.result: Any = None
+        self.error: Exception | None = None
+
+
+class NeuralMemoryMcpClient:
+    """Python port of NeuralMemoryMcpClient (mcp-client.ts).
+
+    Thread-safe: Hermes runs tools and hooks from multiple threads.
+    """
+
+    def __init__(self, python_path: str, brain: str, timeout: int = DEFAULT_TIMEOUT,
+                 init_timeout: int = 90_000) -> None:
+        self._python_path = python_path
+        self._brain = brain
+        self._timeout = timeout
+        self._init_timeout = init_timeout
+        self._proc: subprocess.Popen | None = None
+        self._request_id = 0
+        self._pending: dict[int, _Pending] = {}
+        self._lock = threading.Lock()          # guards _proc/_pending/_request_id writes
+        self._write_lock = threading.Lock()    # serializes stdin writes
+        self._connected = False
+        self._connecting: threading.Event | None = None
+        self._connect_error: Exception | None = None
+
+    @property
+    def connected(self) -> bool:
+        return self._connected
+
+    # ── Connection management ─────────────────────────
+
+    def ensure_connected(self) -> None:
+        """Ensure connected; concurrent callers share one connection attempt.
+
+        Port of ensureConnected().
+        """
+        if self._connected:
+            return
+        connector = False
+        with self._lock:
+            if self._connected:
+                return
+            if self._connecting is not None:
+                gate = self._connecting
+            else:
+                gate = threading.Event()
+                self._connecting = gate
+                self._connect_error = None
+                connector = True
+        if not connector:
+            gate.wait(self._init_timeout / 1000 + 30)
+            if self._connect_error:
+                raise self._connect_error
+            if not self._connected:
+                raise RuntimeError("NeuralMemory MCP connect timed out")
+            return
+        try:
+            self.connect()
+            self._connected = True
+        except Exception as exc:  # noqa: BLE001 — re-raised to all waiters
+            self._connect_error = exc
+            raise
+        finally:
+            with self._lock:
+                self._connecting = None
+            gate.set()
+
+    def connect(self) -> None:
+        """Spawn the MCP process and complete the initialize handshake. Port of connect()."""
+        env = build_child_env(self._brain)
+        self._stderr_lines: list[str] = []
+
+        try:
+            self._proc = subprocess.Popen(
+                [self._python_path, "-m", "neural_memory.mcp"],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=env,
+                bufsize=0,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                f'MCP process error: "{self._python_path}" not found. '
+                "Check pythonPath in plugin config."
+            ) from exc
+
+        # Reader threads for stdout (JSON-RPC) and stderr (diagnostics)
+        threading.Thread(target=self._read_stdout, daemon=True,
+                         name="nmem-mcp-stdout").start()
+        threading.Thread(target=self._read_stderr, daemon=True,
+                         name="nmem-mcp-stderr").start()
+        threading.Thread(target=self._wait_exit, daemon=True,
+                         name="nmem-mcp-exit").start()
+
+        # MCP initialize handshake (uses longer timeout for cold starts)
+        try:
+            self.send("initialize", {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": CLIENT_NAME, "version": CLIENT_VERSION},
+            }, timeout_override=self._init_timeout)
+        except Exception as err:
+            stderr = "\n".join(self._stderr_lines)
+            detail = (f"\nPython stderr:\n{stderr}" if stderr
+                      else "\nNo stderr output — the Python process may have hung.")
+            raise RuntimeError(
+                f"MCP initialize failed: {err}{detail}\n"
+                f"Verify: {self._python_path} -m neural_memory.mcp"
+            ) from err
+
+        # Send initialized notification (no response expected)
+        self._notify("notifications/initialized", {})
+        self._connected = True
+        logger.info("MCP connected (brain: %s, protocol: %s)", self._brain, PROTOCOL_VERSION)
+
+    def list_tools(self) -> list[dict]:
+        """Fetch all available tools via tools/list. Port of listTools()."""
+        result = self.send("tools/list", {})
+        if not isinstance(result, dict):
+            return []
+        return result.get("tools") or []
+
+    def call_tool(self, name: str, args: dict | None = None) -> str:
+        """Call an MCP tool and return its first text content. Port of callTool()."""
+        result = self.send("tools/call", {"name": name, "arguments": args or {}})
+        if not isinstance(result, dict):
+            return ""
+        if result.get("isError"):
+            content = result.get("content") or []
+            text = content[0].get("text") if content and isinstance(content[0], dict) else None
+            raise RuntimeError(text or "Unknown MCP error")
+        content = result.get("content") or []
+        if content and isinstance(content[0], dict):
+            return content[0].get("text") or ""
+        return ""
+
+    def close(self) -> None:
+        """Terminate the child process. Port of close()."""
+        self._connected = False
+        self._reject_all(RuntimeError("Client closing"))
+        proc, self._proc = self._proc, None
+        if proc is not None:
+            try:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=3)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+            except Exception:  # noqa: BLE001 — best-effort teardown
+                pass
+        logger.info("MCP client closed")
+
+    # ── JSON-RPC protocol layer ──────────────────────────
+
+    def send(self, method: str, params: Any, timeout_override: int | None = None) -> Any:
+        """Send a request and wait for its response. Port of send()."""
+        proc = self._proc
+        if proc is None or proc.stdin is None:
+            raise RuntimeError("MCP process not available")
+
+        with self._lock:
+            self._request_id += 1
+            req_id = self._request_id
+            pending = _Pending()
+            self._pending[req_id] = pending
+
+        ms = timeout_override if timeout_override is not None else self._timeout
+        self._write_message({"jsonrpc": "2.0", "id": req_id, "method": method, "params": params})
+
+        if not pending.event.wait(ms / 1000):
+            with self._lock:
+                self._pending.pop(req_id, None)
+            raise RuntimeError(f"MCP timeout: {method} ({ms}ms)")
+
+        if pending.error is not None:
+            raise pending.error
+        return pending.result
+
+    def _notify(self, method: str, params: Any) -> None:
+        self._write_message({"jsonrpc": "2.0", "method": method, "params": params})
+
+    def _write_message(self, message: dict) -> None:
+        proc = self._proc
+        if proc is None or proc.stdin is None:
+            return
+        frame = (json.dumps(message, ensure_ascii=False) + "\n").encode("utf-8")
+        with self._write_lock:
+            try:
+                proc.stdin.write(frame)
+                proc.stdin.flush()
+            except (BrokenPipeError, OSError, ValueError):
+                pass
+
+    # ── Reader threads ───────────────────────────────
+
+    def _read_stdout(self) -> None:
+        proc = self._proc
+        if proc is None or proc.stdout is None:
+            return
+        buffered = 0
+        for line in iter(proc.stdout.readline, b""):
+            buffered += len(line)
+            if buffered > MAX_BUFFER_BYTES:
+                logger.error("MCP buffer exceeded %d bytes — killing process", MAX_BUFFER_BYTES)
+                try:
+                    proc.kill()
+                except Exception:  # noqa: BLE001
+                    pass
+                return
+            self._handle_line(line)
+
+    def _read_stderr(self) -> None:
+        proc = self._proc
+        if proc is None or proc.stderr is None:
+            return
+        for raw in iter(proc.stderr.readline, b""):
+            msg = raw.decode("utf-8", errors="replace").strip()
+            if msg:
+                if len(self._stderr_lines) < MAX_STDERR_LINES:
+                    self._stderr_lines.append(msg)
+                logger.warning("[mcp stderr] %s", msg)
+
+    def _wait_exit(self) -> None:
+        proc = self._proc
+        if proc is None:
+            return
+        code = proc.wait()
+        self._connected = False
+        hint = " — check that neural-memory is installed: pip install neural-memory" if code == 1 else ""
+        self._reject_all(RuntimeError(f"MCP process exited with code {code}{hint}"))
+        logger.error("MCP process exited (code: %s)%s", code, hint)
+
+    def _handle_line(self, line: bytes) -> None:
+        text = line.decode("utf-8", errors="replace").strip()
+        if not text:
+            return
+        try:
+            message = json.loads(text)
+        except json.JSONDecodeError as err:
+            logger.error("Failed to parse MCP message: %s", err)
+            return
+        self._handle_message(message)
+
+    def _handle_message(self, message: dict) -> None:
+        # Notifications (no id) — ignore silently
+        if message.get("id") is None:
+            return
+        with self._lock:
+            pending = self._pending.pop(message.get("id"), None)
+        if pending is None:
+            return
+        error = message.get("error")
+        if error:
+            pending.error = RuntimeError(f"MCP error {error.get('code')}: {error.get('message')}")
+        else:
+            pending.result = message.get("result")
+        pending.event.set()
+
+    def _reject_all(self, error: Exception) -> None:
+        with self._lock:
+            pendings = list(self._pending.values())
+            self._pending.clear()
+        for pending in pendings:
+            pending.error = error
+            pending.event.set()

--- a/integrations/hermes-neuralmemory/mcp_client.py
+++ b/integrations/hermes-neuralmemory/mcp_client.py
@@ -14,8 +14,7 @@ import logging
 import os
 import subprocess
 import threading
-import time
-from typing import Any, Callable
+from typing import Any
 
 logger = logging.getLogger("hermes.plugins.neuralmemory")
 
@@ -64,7 +63,7 @@ def build_child_env(brain: str) -> dict[str, str]:
 
 
 class _Pending:
-    __slots__ = ("event", "result", "error")
+    __slots__ = ("error", "event", "result")
 
     def __init__(self) -> None:
         self.event = threading.Event()
@@ -127,7 +126,7 @@ class NeuralMemoryMcpClient:
         try:
             self.connect()
             self._connected = True
-        except Exception as exc:  # noqa: BLE001 — re-raised to all waiters
+        except Exception as exc:
             self._connect_error = exc
             raise
         finally:
@@ -217,7 +216,7 @@ class NeuralMemoryMcpClient:
                     proc.wait(timeout=3)
                 except subprocess.TimeoutExpired:
                     proc.kill()
-            except Exception:  # noqa: BLE001 — best-effort teardown
+            except Exception:  # noqa: BLE001, S110 — best-effort teardown
                 pass
         logger.info("MCP client closed")
 
@@ -259,7 +258,7 @@ class NeuralMemoryMcpClient:
             try:
                 proc.stdin.write(frame)
                 proc.stdin.flush()
-            except (BrokenPipeError, OSError, ValueError):
+            except (BrokenPipeError, OSError, ValueError):  # noqa: S110 — dead-pipe writes are expected after process exit
                 pass
 
     # ── Reader threads ───────────────────────────────

--- a/integrations/hermes-neuralmemory/plugin.yaml
+++ b/integrations/hermes-neuralmemory/plugin.yaml
@@ -1,0 +1,16 @@
+name: neuralmemory
+version: 1.0.0
+description: "NeuralMemory — brain-inspired persistent memory for Hermes agents (port of the OpenClaw plugin). Neurons, synapses, fibers: spreading-activation recall, auto-context injection, auto-capture."
+author: "nhadaututtheky (original), Rei Stewart (Hermes port)"
+provides_tools:
+  - nmem_remember
+  - nmem_recall
+  - nmem_context
+  - nmem_stats
+  - nmem_health
+  - memory_search
+  - memory_get
+provides_hooks:
+  - pre_llm_call
+  - post_llm_call
+  - on_session_reset

--- a/integrations/hermes-neuralmemory/plugin.yaml
+++ b/integrations/hermes-neuralmemory/plugin.yaml
@@ -14,3 +14,4 @@ provides_hooks:
   - pre_llm_call
   - post_llm_call
   - on_session_reset
+  - on_session_end

--- a/integrations/hermes-neuralmemory/tests/neuralmemory_plugin_test.py
+++ b/integrations/hermes-neuralmemory/tests/neuralmemory_plugin_test.py
@@ -172,6 +172,15 @@ class TestRegexPipelines(unittest.TestCase):
         self.assertNotIn("[concept]", out)
         self.assertNotIn("OK.", out)
 
+    def test_sanitize_capture_requires_whitespace_after_bracket(self):
+        """MINOR-3: sanitize pipeline uses canon's stricter \\]\\s variant."""
+        # "- [fact]x" (no space) must SURVIVE sanitize (canon keeps it)...
+        out = self.hooks.sanitize_auto_capture("- [fact]x\nWe fixed the bug.")
+        self.assertIn("- [fact]x", out)
+        # ...while "- [fact] x" (with space) is stripped
+        out2 = self.hooks.sanitize_auto_capture("- [fact] junk\nWe fixed the bug.")
+        self.assertNotIn("- [fact]", out2)
+
 
 class TestToolWiring(unittest.TestCase):
     def setUp(self):
@@ -301,6 +310,22 @@ class TestHooks(unittest.TestCase):
         self.assertEqual(mcp.calls, [("nmem_auto",
                                       {"action": "process", "text": "[session boundary — reset]"})])
 
+    def test_session_end_closes_client_and_evicts_pool(self):
+        """MINOR-2: port of service.stop() — close + pool eviction."""
+
+        class _ClosableMcp(_FakeMcp):
+            def __init__(self, **kw):
+                super().__init__(**kw)
+                self.closed = False
+
+            def close(self):
+                self.closed = True
+
+        mcp = _ClosableMcp()
+        hook = self.hooks.make_session_end_hook(mcp, self.cfg)
+        hook()
+        self.assertTrue(mcp.closed)
+
 
 class TestRegistration(unittest.TestCase):
     def test_register_wires_tools_and_hooks(self):
@@ -309,7 +334,8 @@ class TestRegistration(unittest.TestCase):
         self.assertEqual(sorted(ctx.tools),
                          sorted(["nmem_remember", "nmem_recall", "nmem_context",
                                  "nmem_stats", "nmem_health", "memory_search", "memory_get"]))
-        self.assertEqual(set(ctx.hooks), {"pre_llm_call", "post_llm_call", "on_session_reset"})
+        self.assertEqual(set(ctx.hooks),
+                         {"pre_llm_call", "post_llm_call", "on_session_reset", "on_session_end"})
 
 
 class TestMcpClientConstants(unittest.TestCase):

--- a/integrations/hermes-neuralmemory/tests/test_neuralmemory_plugin.py
+++ b/integrations/hermes-neuralmemory/tests/test_neuralmemory_plugin.py
@@ -333,6 +333,35 @@ class TestMcpClientConstants(unittest.TestCase):
         self.assertEqual(env.get("NEURALMEMORY_BRAIN"), "custom-brain")
         self.assertNotIn("NEURALMEMORY_BRAIN", mcp_client.build_child_env("default"))
 
+    def test_drain_buffer_consumes_parsed_lines(self):
+        """M1 fix: the cap applies to the UNDRAINED buffer, not cumulative bytes."""
+        from hermes_plugins.neuralmemory import mcp_client
+        client = mcp_client.NeuralMemoryMcpClient("python", "b")
+        seen: list[dict] = []
+        client._handle_message = lambda m: seen.append(m)
+        buf = b'{"id":1,"result":{}}\n{"id":2,"result":{"x":1}}\n{"partial"'
+        rest = client._drain_buffer(buf)
+        self.assertEqual(rest, b'{"partial"')  # partial line stays buffered
+        self.assertEqual(len(seen), 2)
+
+    def test_pool_keyed_by_pythonpath_and_brain(self):
+        """M3 fix: pool reuses one client per (pythonPath, brain) across calls."""
+        import hermes_plugins.neuralmemory as plugin
+        from hermes_plugins.neuralmemory.config import resolve_config
+        cfg_a = resolve_config({"brain": "a"})
+        cfg_a2 = resolve_config({"brain": "a"})
+        cfg_b = resolve_config({"brain": "b"})
+        plugin._mcp_clients.clear()
+        try:
+            c1 = plugin._get_or_create_mcp_client(cfg_a)
+            c2 = plugin._get_or_create_mcp_client(cfg_a2)
+            c3 = plugin._get_or_create_mcp_client(cfg_b)
+            self.assertIs(c1, c2)
+            self.assertIsNot(c1, c3)
+            self.assertEqual(len(plugin._mcp_clients), 2)
+        finally:
+            plugin._mcp_clients.clear()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/integrations/hermes-neuralmemory/tests/test_neuralmemory_plugin.py
+++ b/integrations/hermes-neuralmemory/tests/test_neuralmemory_plugin.py
@@ -1,0 +1,338 @@
+"""Unit tests for the NeuralMemory Hermes plugin port.
+
+Covers the pure-function surface (config resolution, schema normalization,
+regex hygiene pipelines, fallback/compat tool wiring, hook behavior) without
+spawning the MCP subprocess. E2E against a live nmem-mcp server was verified
+separately during development (connect -> 63-tool discovery -> remember ->
+recall -> stats round-trip).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+import unittest
+from importlib import util as importlib_util
+from pathlib import Path
+from unittest import mock
+
+PLUGIN_DIR = Path(__file__).resolve().parent.parent
+
+
+def _load_plugin_module():
+    """Load the plugin the way Hermes's loader does (as a package)."""
+    ns = types.ModuleType("hermes_plugins")
+    ns.__path__ = []
+    sys.modules.setdefault("hermes_plugins", ns)
+    spec = importlib_util.spec_from_file_location(
+        "hermes_plugins.neuralmemory",
+        PLUGIN_DIR / "__init__.py",
+        submodule_search_locations=[str(PLUGIN_DIR)],
+    )
+    mod = importlib_util.module_from_spec(spec)
+    mod.__package__ = "hermes_plugins.neuralmemory"
+    mod.__path__ = [str(PLUGIN_DIR)]
+    sys.modules["hermes_plugins.neuralmemory"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Load the plugin package at import time so `from hermes_plugins.neuralmemory
+# import ...` works in every test class.
+_load_plugin_module()
+
+
+class _MockCtx:
+    def __init__(self):
+        self.tools: list[str] = []
+        self.hooks: dict[str, list] = {}
+
+    def register_tool(self, name, toolset, schema, handler, description=None, **kw):
+        self.tools.append(name)
+
+    def register_hook(self, hook_name, cb):
+        self.hooks.setdefault(hook_name, []).append(cb)
+
+
+class _FakeMcp:
+    """Duck-typed stand-in for NeuralMemoryMcpClient (no subprocess)."""
+
+    def __init__(self, connected=True, recall_payload=None):
+        self.connected = connected
+        self.recall_payload = recall_payload or {"answer": "memory", "confidence": 0.9}
+        self.calls: list[tuple[str, dict]] = []
+
+    def ensure_connected(self):
+        self.connected = True
+
+    def call_tool(self, name, args=None):
+        self.calls.append((name, args or {}))
+        if name == "nmem_recall":
+            return json.dumps(self.recall_payload)
+        return json.dumps({"ok": True})
+
+
+class TestConfig(unittest.TestCase):
+    def setUp(self):
+        from hermes_plugins.neuralmemory import config as cfg_mod
+        self.cfg = cfg_mod
+
+    def test_defaults_when_empty(self):
+        c = self.cfg.resolve_config(None)
+        self.assertEqual(c.python_path, "python")
+        self.assertEqual(c.brain, "default")
+        self.assertTrue(c.auto_context)
+        self.assertTrue(c.auto_capture)
+        self.assertTrue(c.auto_flush)
+        self.assertTrue(c.auto_consolidate)
+        self.assertEqual(c.context_depth, 1)
+        self.assertEqual(c.max_context_tokens, 500)
+        self.assertEqual(c.timeout, 30_000)
+        self.assertEqual(c.init_timeout, 90_000)
+
+    def test_brain_name_validation(self):
+        self.assertEqual(self.cfg.resolve_config({"brain": "valid-brain_1.2"}).brain, "valid-brain_1.2")
+        self.assertEqual(self.cfg.resolve_config({"brain": "bad brain!"}).brain, "default")
+        self.assertEqual(self.cfg.resolve_config({"brain": "x" * 65}).brain, "default")
+        self.assertEqual(self.cfg.resolve_config({"brain": 42}).brain, "default")
+
+    def test_range_clamps_match_upstream(self):
+        self.assertEqual(self.cfg.resolve_config({"contextDepth": 4}).context_depth, 1)
+        self.assertEqual(self.cfg.resolve_config({"contextDepth": 0}).context_depth, 0)
+        self.assertEqual(self.cfg.resolve_config({"maxContextTokens": 50}).max_context_tokens, 500)
+        self.assertEqual(self.cfg.resolve_config({"maxContextTokens": 10000}).max_context_tokens, 10000)
+        self.assertEqual(self.cfg.resolve_config({"timeout": 100}).timeout, 30_000)
+        self.assertEqual(self.cfg.resolve_config({"timeout": 120000}).timeout, 120_000)
+        self.assertEqual(self.cfg.resolve_config({"initTimeout": 5000}).init_timeout, 90_000)
+
+    def test_type_coercion(self):
+        c = self.cfg.resolve_config({"autoContext": "yes", "contextDepth": 2.7})
+        self.assertTrue(c.auto_context)  # non-bool falls back to default True
+        self.assertEqual(c.context_depth, 1)  # non-int falls back
+
+
+class TestSchemaNormalization(unittest.TestCase):
+    def setUp(self):
+        from hermes_plugins.neuralmemory import tools_proxy
+        self.tp = tools_proxy
+
+    def test_strip_keys_removed(self):
+        src = {"type": "object", "properties": {
+            "n": {"type": "number", "minimum": 0, "maximum": 10, "maxLength": 5}}}
+        out = self.tp.normalize_schema(src)
+        self.assertNotIn("minimum", out["properties"]["n"])
+        self.assertNotIn("maximum", out["properties"]["n"])
+        self.assertNotIn("maxLength", out["properties"]["n"])
+
+    def test_integer_becomes_number(self):
+        out = self.tp.normalize_schema({"type": "integer"})
+        self.assertEqual(out["type"], "number")
+
+    def test_object_gets_properties_and_additional_properties(self):
+        out = self.tp.normalize_schema({"type": "object"})
+        self.assertEqual(out["properties"], {})
+        self.assertFalse(out["additionalProperties"])
+
+    def test_nested_combinators(self):
+        src = {"anyOf": [{"type": "object", "properties": {"a": {"type": "integer"}}}]}
+        out = self.tp.normalize_schema(src)
+        self.assertEqual(out["anyOf"][0]["properties"]["a"]["type"], "number")
+
+    def test_safe_schema_fallback(self):
+        self.assertEqual(self.tp.to_safe_schema(None),
+                         {"type": "object", "properties": {}, "additionalProperties": False})
+        out = self.tp.to_safe_schema({"type": "object", "required": ["x"],
+                                      "properties": {"x": {"type": "string"}}})
+        self.assertEqual(out["required"], ["x"])
+
+
+class TestRegexPipelines(unittest.TestCase):
+    def setUp(self):
+        from hermes_plugins.neuralmemory import hooks
+        self.hooks = hooks
+
+    def test_strip_prompt_metadata_full_pipeline(self):
+        raw = ('{"message_id": 123, "sender": "test"}\n'
+               '## Relevant Memories\n- [concept] junk neuron\n'
+               '[NeuralMemory — relevant context]\n'
+               'export FOO=bar\n'
+               'what is the deployment config?')
+        self.assertEqual(self.hooks.strip_prompt_metadata(raw),
+                         "what is the deployment config?")
+
+    def test_strip_prompt_metadata_fallback_last_line(self):
+        cleaned = self.hooks.strip_prompt_metadata("## Relevant Memories\n- [concept] x")
+        self.assertTrue(cleaned)  # never returns empty
+
+    def test_sanitize_auto_capture(self):
+        out = self.hooks.sanitize_auto_capture(
+            "## Relevant Memories\nstuff\nOK.\nDone\nWe chose PostgreSQL because of JSONB support.")
+        self.assertIn("PostgreSQL", out)
+        self.assertNotIn("[concept]", out)
+        self.assertNotIn("OK.", out)
+
+
+class TestToolWiring(unittest.TestCase):
+    def setUp(self):
+        from hermes_plugins.neuralmemory import tools_proxy
+        self.tp = tools_proxy
+
+    def test_fallback_tool_names_and_handlers(self):
+        mcp = _FakeMcp()
+        tools = self.tp.create_fallback_tools(mcp)
+        names = [t["name"] for t in tools]
+        self.assertEqual(names, ["nmem_remember", "nmem_recall", "nmem_context",
+                                 "nmem_stats", "nmem_health"])
+        for t in tools:
+            out = json.loads(t["handler"]({}))
+            self.assertFalse(out.get("error"), f"{t['name']} returned error: {out}")
+        self.assertEqual([c[0] for c in mcp.calls], names)
+
+    def test_compat_shims_route_to_recall(self):
+        mcp = _FakeMcp()
+        search, get = self.tp.create_compatibility_tools(mcp)
+        search["handler"]({"query": "q1"})
+        get["handler"]({"id": "abc"})
+        self.assertEqual(mcp.calls[0], ("nmem_recall", {"query": "q1", "depth": 1}))
+        self.assertEqual(mcp.calls[1], ("nmem_recall", {"query": "abc", "depth": 0}))
+
+    def test_auto_reconnect_error_is_soft(self):
+        class _DeadMcp(_FakeMcp):
+            def ensure_connected(self):
+                raise RuntimeError("no python")
+
+        mcp = _DeadMcp(connected=False)
+        tools = self.tp.create_fallback_tools(mcp)
+        out = json.loads(tools[0]["handler"]({"content": "x"}))
+        self.assertTrue(out["error"])
+        self.assertIn("auto-connect failed", out["message"])
+
+    def test_memory_type_enum_matches_upstream(self):
+        mcp = _FakeMcp()
+        remember = self.tp.create_fallback_tools(mcp)[0]
+        enum = remember["parameters"]["properties"]["type"]["enum"]
+        self.assertEqual(enum, ["fact", "decision", "preference", "todo", "insight",
+                                "context", "instruction", "error", "workflow", "reference"])
+
+
+class TestHooks(unittest.TestCase):
+    def setUp(self):
+        from hermes_plugins.neuralmemory import hooks
+        from hermes_plugins.neuralmemory import tools_proxy
+        from hermes_plugins.neuralmemory.config import resolve_config
+        self.hooks = hooks
+        self.tp = tools_proxy
+        self.cfg = resolve_config(None)
+
+    def test_pre_llm_first_turn_injects_instructions_and_recall(self):
+        mcp = _FakeMcp()
+        tools = self.tp.create_fallback_tools(mcp)
+        hook = self.hooks.make_pre_llm_hook(mcp, self.cfg, tools)
+        out = hook(session_id="s", user_message="hello", conversation_history=[],
+                   is_first_turn=True, model="m", platform="cli")
+        self.assertIn("context", out)
+        self.assertIn("Neural Memory", out["context"])
+        self.assertIn("relevant context", out["context"])
+
+    def test_pre_llm_later_turn_recall_only(self):
+        mcp = _FakeMcp()
+        tools = self.tp.create_fallback_tools(mcp)
+        hook = self.hooks.make_pre_llm_hook(mcp, self.cfg, tools)
+        out = hook(session_id="s", user_message="hello", conversation_history=[],
+                   is_first_turn=False)
+        self.assertIn("relevant context", out["context"])
+        self.assertNotIn("WHEN TO RECALL", out["context"])
+
+    def test_pre_llm_low_confidence_skips_recall(self):
+        mcp = _FakeMcp(recall_payload={"answer": "weak", "confidence": 0.05})
+        hook = self.hooks.make_pre_llm_hook(mcp, self.cfg,
+                                            self.tp.create_fallback_tools(mcp))
+        self.assertIsNone(hook(session_id="s", user_message="x",
+                               conversation_history=[], is_first_turn=False))
+
+    def test_pre_llm_disconnected_skips_recall(self):
+        mcp = _FakeMcp(connected=False)
+        hook = self.hooks.make_pre_llm_hook(mcp, self.cfg,
+                                            self.tp.create_fallback_tools(mcp))
+        self.assertIsNone(hook(session_id="s", user_message="x",
+                               conversation_history=[], is_first_turn=False))
+        self.assertEqual(mcp.calls, [])
+
+    def test_pre_llm_recall_failure_never_raises(self):
+        class _Exploding(_FakeMcp):
+            def call_tool(self, name, args=None):
+                raise RuntimeError("boom")
+
+        mcp = _Exploding()
+        hook = self.hooks.make_pre_llm_hook(mcp, self.cfg,
+                                            self.tp.create_fallback_tools(mcp))
+        self.assertIsNone(hook(session_id="s", user_message="x",
+                               conversation_history=[], is_first_turn=False))
+
+    def test_post_llm_captures_long_assistant_text(self):
+        mcp = _FakeMcp()
+        hook = self.hooks.make_post_llm_hook(mcp, self.cfg)
+        hook(session_id="s", user_message="q",
+             assistant_response="We decided to keep the port faithful to the upstream plugin.",
+             conversation_history=[{"role": "assistant",
+                                    "content": "We decided to keep the port faithful to the upstream plugin."}])
+        self.assertEqual(mcp.calls[0][0], "nmem_auto")
+        self.assertEqual(mcp.calls[0][1]["action"], "process")
+
+    def test_post_llm_skips_short_acknowledgement(self):
+        mcp = _FakeMcp()
+        hook = self.hooks.make_post_llm_hook(mcp, self.cfg)
+        hook(session_id="s", user_message="q", assistant_response="OK.",
+             conversation_history=[{"role": "assistant", "content": "OK."}])
+        self.assertEqual(mcp.calls, [])
+
+    def test_post_llm_disconnected_is_noop(self):
+        mcp = _FakeMcp(connected=False)
+        hook = self.hooks.make_post_llm_hook(mcp, self.cfg)
+        hook(session_id="s", user_message="q", assistant_response="x" * 100,
+             conversation_history=[])
+        self.assertEqual(mcp.calls, [])
+
+    def test_session_reset_flush(self):
+        mcp = _FakeMcp()
+        hook = self.hooks.make_session_reset_hook(mcp, self.cfg)
+        hook(session_key="s1")
+        self.assertEqual(mcp.calls, [("nmem_auto",
+                                      {"action": "process", "text": "[session boundary — reset]"})])
+
+
+class TestRegistration(unittest.TestCase):
+    def test_register_wires_tools_and_hooks(self):
+        ctx = _MockCtx()
+        _load_plugin_module().register(ctx)
+        self.assertEqual(sorted(ctx.tools),
+                         sorted(["nmem_remember", "nmem_recall", "nmem_context",
+                                 "nmem_stats", "nmem_health", "memory_search", "memory_get"]))
+        self.assertEqual(set(ctx.hooks), {"pre_llm_call", "post_llm_call", "on_session_reset"})
+
+
+class TestMcpClientConstants(unittest.TestCase):
+    def test_protocol_constants_match_upstream(self):
+        from hermes_plugins.neuralmemory import mcp_client
+        self.assertEqual(mcp_client.PROTOCOL_VERSION, "2024-11-05")
+        self.assertEqual(mcp_client.MAX_BUFFER_BYTES, 10 * 1024 * 1024)
+        self.assertEqual(mcp_client.DEFAULT_TIMEOUT, 30_000)
+
+    def test_env_allowlist(self):
+        from hermes_plugins.neuralmemory import mcp_client
+        expected = {"PATH", "PATHEXT", "HOME", "USERPROFILE", "SYSTEMROOT", "TEMP",
+                    "TMP", "LANG", "LC_ALL", "VIRTUAL_ENV", "CONDA_PREFIX",
+                    "PYTHONPATH", "PYTHONHOME", "NEURALMEMORY_DIR", "NEURALMEMORY_BRAIN",
+                    "NEURAL_MEMORY_DIR", "NEURAL_MEMORY_JSON", "NEURAL_MEMORY_DEBUG"}
+        self.assertEqual(set(mcp_client.ALLOWED_ENV_KEYS), expected)
+
+    def test_build_child_env_brain(self):
+        from hermes_plugins.neuralmemory import mcp_client
+        env = mcp_client.build_child_env("custom-brain")
+        self.assertEqual(env.get("NEURALMEMORY_BRAIN"), "custom-brain")
+        self.assertNotIn("NEURALMEMORY_BRAIN", mcp_client.build_child_env("default"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integrations/hermes-neuralmemory/tools_proxy.py
+++ b/integrations/hermes-neuralmemory/tools_proxy.py
@@ -94,7 +94,7 @@ def make_call_fn(mcp) -> Callable[[str, dict], str]:
         if not mcp.connected:
             try:
                 mcp.ensure_connected()
-            except Exception as err:  # noqa: BLE001
+            except Exception as err:
                 return json.dumps({
                     "error": True,
                     "message": f"NeuralMemory auto-connect failed: {err}",
@@ -105,7 +105,7 @@ def make_call_fn(mcp) -> Callable[[str, dict], str]:
                 return json.dumps(json.loads(raw))
             except (json.JSONDecodeError, TypeError):
                 return json.dumps({"text": raw})
-        except Exception as err:  # noqa: BLE001
+        except Exception as err:
             return json.dumps({
                 "error": True,
                 "message": f"Tool {tool_name} failed: {err}",

--- a/integrations/hermes-neuralmemory/tools_proxy.py
+++ b/integrations/hermes-neuralmemory/tools_proxy.py
@@ -7,7 +7,8 @@ same 5 fallback tools and 2 compat shims with identical schemas.
 from __future__ import annotations
 
 import json
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 # ── Schema normalization ───────────────────────────
 
@@ -247,10 +248,15 @@ def create_tools_from_mcp(mcp) -> list[dict]:
     call = make_call_fn(mcp)
     tools = []
     for t in mcp_tools:
+        tool_name = t.get("name", "")
+
+        def _make_handler(name: str):
+            return lambda params, **kw: call(name, params)
+
         tools.append({
-            "name": t.get("name", ""),
-            "description": t.get("description") or f"NeuralMemory tool: {t.get('name')}",
+            "name": tool_name,
+            "description": t.get("description") or f"NeuralMemory tool: {tool_name}",
             "parameters": to_safe_schema(t.get("inputSchema")),
-            "handler": (lambda name: lambda params, **kw: call(name, params))(t.get("name", "")),
+            "handler": _make_handler(tool_name),
         })
     return tools

--- a/integrations/hermes-neuralmemory/tools_proxy.py
+++ b/integrations/hermes-neuralmemory/tools_proxy.py
@@ -1,0 +1,256 @@
+"""Tool schemas + normalization — port of integrations/neuralmemory/src/tools.ts.
+
+Faithful port: same STRIP_KEYS set, same normalization algorithm,
+same 5 fallback tools and 2 compat shims with identical schemas.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Callable
+
+# ── Schema normalization ───────────────────────────
+
+# Keywords that some LLM providers reject in function schemas.
+STRIP_KEYS = frozenset([
+    "minimum",
+    "maximum",
+    "maxLength",
+    "minLength",
+    "maxItems",
+    "minItems",
+    "exclusiveMinimum",
+    "exclusiveMaximum",
+])
+
+
+def normalize_schema(node: Any) -> Any:
+    """Recursively normalize a JSON Schema node for provider compatibility.
+
+    Port of normalizeSchema(): strip constraint keywords, replace integer
+    with number (Gemini compat), add additionalProperties:false to objects
+    (OpenAI strict mode), ensure every object has properties (Anthropic SDK).
+    """
+    if node is None or not isinstance(node, (dict, list)):
+        return node
+
+    if isinstance(node, list):
+        return [normalize_schema(item) for item in node]
+
+    result: dict[str, Any] = {}
+    for key, value in node.items():
+        if key in STRIP_KEYS:
+            continue
+        if key == "type" and value == "integer":
+            result[key] = "number"
+        elif key == "properties" and isinstance(value, dict):
+            result[key] = {prop_name: normalize_schema(prop_schema)
+                           for prop_name, prop_schema in value.items()}
+        elif key == "items" and isinstance(value, dict):
+            result[key] = normalize_schema(value)
+        elif key in ("anyOf", "oneOf", "allOf") and isinstance(value, list):
+            result[key] = [normalize_schema(item) for item in value]
+        else:
+            result[key] = value
+
+    # Ensure objects have `properties` and `additionalProperties`
+    if result.get("type") == "object":
+        if result.get("properties") is None:
+            result["properties"] = {}
+        if "additionalProperties" not in result:
+            result["additionalProperties"] = False
+
+    return result
+
+
+def to_safe_schema(input_schema: dict | None) -> dict:
+    """Convert an MCP inputSchema into a provider-safe schema. Port of toSafeSchema()."""
+    if not input_schema or not isinstance(input_schema, dict):
+        return {"type": "object", "properties": {}, "additionalProperties": False}
+
+    normalized = normalize_schema(input_schema)
+    schema: dict[str, Any] = {
+        "type": "object",
+        "properties": normalized.get("properties") or {},
+        "additionalProperties": False,
+    }
+    required = normalized.get("required")
+    if isinstance(required, list) and required:
+        schema["required"] = required
+    return schema
+
+
+# ── Tool factory ────────────────────────────────
+
+def make_call_fn(mcp) -> Callable[[str, dict], str]:
+    """Create a tool-call helper that auto-reconnects to MCP. Port of makeCallFn().
+
+    Returns the raw tool text (Hermes tool handlers return JSON strings,
+    so the handler wrapper JSON-encodes the outcome).
+    """
+
+    def call(tool_name: str, args: dict) -> str:
+        if not mcp.connected:
+            try:
+                mcp.ensure_connected()
+            except Exception as err:  # noqa: BLE001
+                return json.dumps({
+                    "error": True,
+                    "message": f"NeuralMemory auto-connect failed: {err}",
+                })
+        try:
+            raw = mcp.call_tool(tool_name, args)
+            try:
+                return json.dumps(json.loads(raw))
+            except (json.JSONDecodeError, TypeError):
+                return json.dumps({"text": raw})
+        except Exception as err:  # noqa: BLE001
+            return json.dumps({
+                "error": True,
+                "message": f"Tool {tool_name} failed: {err}",
+            })
+
+    return call
+
+
+# ── Fallback tools (registered synchronously at plugin load) ──────
+
+def create_fallback_tools(mcp) -> list[dict]:
+    """Port of createFallbackTools() — 5 core tools, identical schemas."""
+    call = make_call_fn(mcp)
+
+    tools = [
+        {
+            "name": "nmem_remember",
+            "description": (
+                "Store a memory in NeuralMemory. Use this to remember facts, decisions, "
+                "insights, todos, errors, and other information that should persist across sessions."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "content": {"type": "string", "description": "The content to remember"},
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "fact", "decision", "preference", "todo", "insight",
+                            "context", "instruction", "error", "workflow", "reference",
+                        ],
+                        "description": "Memory type (auto-detected if not specified)",
+                    },
+                    "priority": {"type": "number", "description": "Priority 0-10 (5=normal, 10=critical)"},
+                    "tags": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Tags for categorization",
+                    },
+                },
+                "required": ["content"],
+                "additionalProperties": False,
+            },
+            "handler": lambda params, **kw: call("nmem_remember", params),
+        },
+        {
+            "name": "nmem_recall",
+            "description": (
+                "Query memories from NeuralMemory. Use this to recall past information, "
+                "decisions, patterns, or context relevant to the current task."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string", "description": "The query to search memories"},
+                    "depth": {"type": "number", "description": "Search depth: 0=instant, 1=context, 2=habit, 3=deep"},
+                    "max_tokens": {"type": "number", "description": "Maximum tokens in response (default: 500)"},
+                },
+                "required": ["query"],
+                "additionalProperties": False,
+            },
+            "handler": lambda params, **kw: call("nmem_recall", params),
+        },
+        {
+            "name": "nmem_context",
+            "description": "Get recent context from NeuralMemory.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "limit": {"type": "number", "description": "Number of recent memories (default: 10)"},
+                },
+                "additionalProperties": False,
+            },
+            "handler": lambda params, **kw: call("nmem_context", params),
+        },
+        {
+            "name": "nmem_stats",
+            "description": "Get brain statistics including memory counts and freshness.",
+            "parameters": {"type": "object", "properties": {}, "additionalProperties": False},
+            "handler": lambda params, **kw: call("nmem_stats", params),
+        },
+        {
+            "name": "nmem_health",
+            "description": "Get brain health diagnostics including grade and recommendations.",
+            "parameters": {"type": "object", "properties": {}, "additionalProperties": False},
+            "handler": lambda params, **kw: call("nmem_health", params),
+        },
+    ]
+    return tools
+
+
+def create_compatibility_tools(mcp) -> list[dict]:
+    """Port of createCompatibilityTools() — legacy memory-core aliases."""
+    call = make_call_fn(mcp)
+
+    return [
+        {
+            "name": "memory_search",
+            "description": (
+                "Search memories (legacy alias for nmem_recall). "
+                "Prefer nmem_recall for full NeuralMemory features."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string", "description": "The search query"},
+                },
+                "required": ["query"],
+                "additionalProperties": False,
+            },
+            "handler": lambda params, **kw: call("nmem_recall", {"query": params.get("query"), "depth": 1}),
+        },
+        {
+            "name": "memory_get",
+            "description": (
+                "Get a memory by ID (legacy alias for nmem_recall). "
+                "Prefer nmem_recall for full NeuralMemory features."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string", "description": "Memory identifier or query"},
+                },
+                "required": ["id"],
+                "additionalProperties": False,
+            },
+            "handler": lambda params, **kw: call("nmem_recall", {"query": str(params.get("id")), "depth": 0}),
+        },
+    ]
+
+
+def create_tools_from_mcp(mcp) -> list[dict]:
+    """Port of createToolsFromMcp() — dynamic discovery from tools/list.
+
+    Used for diagnostics/logging at startup (Hermes freezes the tool list
+    after register(), so dynamically-discovered tools beyond the fallback
+    set are logged rather than registered — documented adaptation).
+    """
+    mcp_tools = mcp.list_tools()
+    call = make_call_fn(mcp)
+    tools = []
+    for t in mcp_tools:
+        tools.append({
+            "name": t.get("name", ""),
+            "description": t.get("description") or f"NeuralMemory tool: {t.get('name')}",
+            "parameters": to_safe_schema(t.get("inputSchema")),
+            "handler": (lambda name: lambda params, **kw: call(name, params))(t.get("name", "")),
+        })
+    return tools


### PR DESCRIPTION
## Summary

Adds `integrations/hermes-neuralmemory/` — a faithful Python port of the OpenClaw NeuralMemory plugin (`integrations/neuralmemory/`, v1.17.0) to the [Hermes Agent](https://github.com/NousResearch/hermes-agent) plugin API.

Hermes agents currently have no NeuralMemory integration; this gives them the same brain-inspired persistent memory (neurons, synapses, fibers, spreading activation) the OpenClaw plugin provides, against the same `nmem-mcp` server and brain databases.

## Architecture

```
Hermes Agent → neuralmemory plugin (Python) → MCP stdio → nmem-mcp → ~/.neuralmemory/brains/<brain>.db
```

## What's included (parity with the OpenClaw plugin)

- **7 tools registered synchronously**: `nmem_remember`, `nmem_recall`, `nmem_context`, `nmem_stats`, `nmem_health` + compat shims `memory_search`, `memory_get`
- **MCP stdio client**: JSON-RPC 2.0 newline-delimited, 10 MB buffer cap, least-privilege env allowlist (identical key set), 30s request / 90s init timeouts, auto-reconnect on first tool call, thread-safe (Hermes is multi-threaded)
- **Singleton client** per (pythonPath, brain) via Hermes' official `lazy_singleton` helper
- **Schema normalization**: identical algorithm (strip constraint keywords, integer→number, `additionalProperties: false`, ensure `properties`)
- **Hooks**:
  - `pre_llm_call` ← `before_prompt_build` (tool instructions on session first turn + auto-recall context every turn)
  - `post_llm_call` ← `agent_end` (auto-capture: last 5 assistant messages, sanitized, `nmem_auto`)
  - `on_session_reset` ← `before_reset` (boundary flush)
- **Prompt hygiene**: `stripPromptMetadata` and `sanitizeAutoCapture` regex pipelines ported with identical passes and order
- **Config**: same keys/defaults/validation ranges (`pythonPath`, `brain`, `autoContext`, `autoCapture`, `autoFlush`, `autoConsolidate`, `contextDepth` 0–3, `maxContextTokens` 100–10000, `timeout` 5s–120s, `initTimeout` 10s–300s), read from `plugins.entries.neuralmemory.config`

## Documented adaptations (Hermes API differences)

| OpenClaw | Hermes port | Why |
|---|---|---|
| `before_prompt_build` systemPrompt | `pre_llm_call` user-message injection, first turn only | Hermes injects into the user message to preserve prompt caching |
| `before_compaction` flush | dropped | no Hermes plugin-hook equivalent |
| `gateway_start` consolidation | dropped (cron workaround documented) | no Hermes plugin-hook equivalent |
| dynamic tool registration | discovery logged, 7 stable tools registered | Hermes freezes the tool list after `register()` (same constraint as OpenClaw) |

## Verification performed

- `py_compile` clean on all modules
- Load test: 7 tools + 3 hooks registered via mock context
- **Live Hermes run** (`HERMES_PLUGINS_DEBUG=1 hermes chat`): plugin discovered, loaded, registered all 7 tools + 3 hooks from real config
- **E2E MCP round-trip**: connect → `tools/list` (63 tools discovered) → `nmem_remember` (fiber_id returned) → `nmem_recall` (memory retrieved) → `nmem_stats`
- Hook unit checks: both regex pipelines produce exact expected outputs; first-turn/later-turn injection paths verified
- Mechanical parity audit vs the TypeScript source: all checks pass

## Install (from plugin README)

1. `pip install neural-memory` (Python 3.11+)
2. Copy `integrations/hermes-neuralmemory/` → `~/.hermes/plugins/neuralmemory/`
3. Enable in `config.yaml`: `plugins.enabled: [neuralmemory]` + optional `plugins.entries.neuralmemory.config`
4. Restart Hermes
