### PR TITLE
fix(retrieval): enable Chinese short-word FTS recall via cjk_spaced index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **CJK FTS recall**: SQLite's `unicode61` tokenizer treated a CJK run as a
+  single token, so Chinese short-word queries (`起源`, `服务器`) never matched
+  content holding longer CJK phrases. FTS sync triggers now store
+  `cjk_spaced()` text (each hanzi becomes its own token) and the FTS query
+  builders phrase CJK terms the same way; schema v41→v42 rebuilds and
+  backfills the index. English/Vietnamese behavior unchanged.
+
 ## [4.61.0] — 2026-08-09
 
 ### Added — Cognitive Efficiency program (Phases 1–8)

--- a/src/neural_memory/storage/sql/mixins/fibers.py
+++ b/src/neural_memory/storage/sql/mixins/fibers.py
@@ -54,7 +54,8 @@ def _build_fts_query(search_term: str) -> str:
     parts: list[str] = []
     for piece in terms:
         if any(is_cjk_char(ch) for ch in piece):
-            parts.append(f'"{(cjk_spaced(piece) or "").strip()}"')
+            escaped = piece.replace(chr(34), chr(34) + chr(34))
+            parts.append(f'"{(cjk_spaced(escaped) or "").strip()}"')
         else:
             parts.append(f'"{piece.replace(chr(34), chr(34) + chr(34))}"')
     return " ".join(parts)

--- a/src/neural_memory/storage/sql/mixins/fibers.py
+++ b/src/neural_memory/storage/sql/mixins/fibers.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from neural_memory.core.fiber import Fiber
 from neural_memory.storage.sql.row_mappers import row_to_fiber
+from neural_memory.utils.cjk import cjk_spaced, is_cjk_char
 from neural_memory.utils.tag_normalizer import normalize_tags_lower
 from neural_memory.utils.timeutils import utcnow
 
@@ -40,11 +41,23 @@ logger = logging.getLogger(__name__)
 
 
 def _build_fts_query(search_term: str) -> str:
-    """Build an FTS5 MATCH expression from a user search string."""
-    tokens = search_term.split()
-    if not tokens:
+    """Build an FTS5 MATCH expression from a user search string.
+
+    Splits on whitespace, quotes each piece to escape FTS5 operators
+    (AND, OR, NOT, NEAR, *, etc.), and joins with implicit AND.
+    CJK runs are spaced (see utils/cjk.py) and quoted as a phrase so
+    Chinese short words match the cjk_spaced() index.
+    """
+    terms = search_term.split()
+    if not terms:
         return '""'
-    return " ".join(f'"{token.replace(chr(34), chr(34) + chr(34))}"' for token in tokens)
+    parts: list[str] = []
+    for piece in terms:
+        if any(is_cjk_char(ch) for ch in piece):
+            parts.append(f'"{cjk_spaced(piece).strip()}"')
+        else:
+            parts.append(f'"{piece.replace(chr(34), chr(34) + chr(34))}"')
+    return " ".join(parts)
 
 
 # ---------------------------------------------------------------------------

--- a/src/neural_memory/storage/sql/mixins/fibers.py
+++ b/src/neural_memory/storage/sql/mixins/fibers.py
@@ -54,7 +54,7 @@ def _build_fts_query(search_term: str) -> str:
     parts: list[str] = []
     for piece in terms:
         if any(is_cjk_char(ch) for ch in piece):
-            parts.append(f'"{cjk_spaced(piece).strip()}"')
+            parts.append(f'"{(cjk_spaced(piece) or "").strip()}"')
         else:
             parts.append(f'"{piece.replace(chr(34), chr(34) + chr(34))}"')
     return " ".join(parts)

--- a/src/neural_memory/storage/sql/mixins/neurons.py
+++ b/src/neural_memory/storage/sql/mixins/neurons.py
@@ -53,7 +53,7 @@ def _build_fts_query(search_term: str) -> str:
     parts: list[str] = []
     for piece in terms:
         if any(is_cjk_char(ch) for ch in piece):
-            parts.append(f'"{cjk_spaced(piece).strip()}"')
+            parts.append(f'"{(cjk_spaced(piece) or "").strip()}"')
         else:
             parts.append(f'"{piece.replace(chr(34), chr(34) + chr(34))}"')
     return " ".join(parts)

--- a/src/neural_memory/storage/sql/mixins/neurons.py
+++ b/src/neural_memory/storage/sql/mixins/neurons.py
@@ -53,7 +53,8 @@ def _build_fts_query(search_term: str) -> str:
     parts: list[str] = []
     for piece in terms:
         if any(is_cjk_char(ch) for ch in piece):
-            parts.append(f'"{(cjk_spaced(piece) or "").strip()}"')
+            escaped = piece.replace(chr(34), chr(34) + chr(34))
+            parts.append(f'"{(cjk_spaced(escaped) or "").strip()}"')
         else:
             parts.append(f'"{piece.replace(chr(34), chr(34) + chr(34))}"')
     return " ".join(parts)

--- a/src/neural_memory/storage/sql/mixins/neurons.py
+++ b/src/neural_memory/storage/sql/mixins/neurons.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any
 
 from neural_memory.core.neuron import Neuron, NeuronState, NeuronType
 from neural_memory.storage.sql.row_mappers import row_to_neuron, row_to_neuron_state
+from neural_memory.utils.cjk import cjk_spaced, is_cjk_char
 from neural_memory.utils.timeutils import utcnow
 
 if TYPE_CHECKING:
@@ -41,32 +42,43 @@ _HASH_SNAPSHOT_TTL_SECONDS = 5.0
 def _build_fts_query(search_term: str) -> str:
     """Build an FTS5 MATCH expression from a user search string.
 
-    Splits on whitespace, quotes each token to escape FTS5 operators
+    Splits on whitespace, quotes each piece to escape FTS5 operators
     (AND, OR, NOT, NEAR, *, etc.), and joins with implicit AND.
-    Double quotes within tokens are escaped by doubling them.
-    Example: 'API design' -> '"API" "design"'
+    CJK runs are spaced (see utils/cjk.py) and quoted as a phrase so
+    Chinese short words match the cjk_spaced() index.
     """
-    tokens = search_term.split()
-    if not tokens:
+    terms = search_term.split()
+    if not terms:
         return '""'
-    return " ".join(f'"{token.replace(chr(34), chr(34) + chr(34))}"' for token in tokens)
+    parts: list[str] = []
+    for piece in terms:
+        if any(is_cjk_char(ch) for ch in piece):
+            parts.append(f'"{cjk_spaced(piece).strip()}"')
+        else:
+            parts.append(f'"{piece.replace(chr(34), chr(34) + chr(34))}"')
+    return " ".join(parts)
 
 
 def _build_fts_prefix_query(prefix: str) -> str:
-    """Build FTS5 MATCH with prefix on last token.
+    """Build FTS5 MATCH with prefix on last piece.
 
-    All tokens except the last are quoted (exact match).
-    The last token is sanitized and gets a ``*`` suffix (prefix match).
+    All pieces except the last are quoted (exact match).
+    The last piece is sanitized and gets a ``*`` suffix (prefix match).
     Example: ``'API des'`` -> ``'"API" des*'``
+
+    CJK queries fall back to exact phrase matching - a spaced single-char
+    piece sequence has no meaningful FTS5 prefix semantics.
     """
-    tokens = prefix.split()
-    if not tokens:
+    terms = prefix.split()
+    if not terms:
         return '""'
+    if any(is_cjk_char(ch) for piece in terms for ch in piece):
+        return _build_fts_query(prefix)
     parts: list[str] = []
-    for token in tokens[:-1]:
-        escaped = token.replace(chr(34), chr(34) + chr(34))
+    for piece in terms[0:-1]:
+        escaped = piece.replace(chr(34), chr(34) + chr(34))
         parts.append(f'"{escaped}"')
-    last = re.sub(r"[^\w]", "", tokens[-1], flags=re.UNICODE)
+    last = re.sub(r"[^\w]", "", terms[-1], flags=re.UNICODE)
     if last:
         parts.append(f"{last}*")
     return " ".join(parts) if parts else '""'

--- a/src/neural_memory/storage/sql/sqlite_dialect.py
+++ b/src/neural_memory/storage/sql/sqlite_dialect.py
@@ -12,6 +12,7 @@ import aiosqlite
 
 from neural_memory.storage.read_pool import DEFAULT_POOL_SIZE, ReadPool
 from neural_memory.storage.sql.dialect import Dialect
+from neural_memory.utils.cjk import cjk_spaced
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +74,11 @@ class SQLiteDialect(Dialect):
 
         self._conn = await aiosqlite.connect(self._db_path)
         self._conn.row_factory = aiosqlite.Row
+
+        # FTS sync triggers call cjk_spaced() so the index stores
+        # CJK-spaced text (see utils/cjk.py). Must be registered before
+        # any write or migration touches the FTS tables.
+        await self._conn.create_function("cjk_spaced", 1, cjk_spaced)
 
         await self._conn.execute("PRAGMA foreign_keys = ON")
         await self._conn.execute("PRAGMA journal_mode=WAL")

--- a/src/neural_memory/storage/sqlite_fibers.py
+++ b/src/neural_memory/storage/sqlite_fibers.py
@@ -29,7 +29,8 @@ def _build_fts_query(search_term: str) -> str:
     parts: list[str] = []
     for piece in terms:
         if any(is_cjk_char(ch) for ch in piece):
-            parts.append(f'"{(cjk_spaced(piece) or "").strip()}"')
+            escaped = piece.replace(chr(34), chr(34) + chr(34))
+            parts.append(f'"{(cjk_spaced(escaped) or "").strip()}"')
         else:
             parts.append(f'"{piece.replace(chr(34), chr(34) + chr(34))}"')
     return " ".join(parts)

--- a/src/neural_memory/storage/sqlite_fibers.py
+++ b/src/neural_memory/storage/sqlite_fibers.py
@@ -29,7 +29,7 @@ def _build_fts_query(search_term: str) -> str:
     parts: list[str] = []
     for piece in terms:
         if any(is_cjk_char(ch) for ch in piece):
-            parts.append(f'"{cjk_spaced(piece).strip()}"')
+            parts.append(f'"{(cjk_spaced(piece) or "").strip()}"')
         else:
             parts.append(f'"{piece.replace(chr(34), chr(34) + chr(34))}"')
     return " ".join(parts)

--- a/src/neural_memory/storage/sqlite_fibers.py
+++ b/src/neural_memory/storage/sqlite_fibers.py
@@ -10,16 +10,29 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from neural_memory.core.fiber import Fiber
 from neural_memory.storage.sqlite_row_mappers import row_to_fiber
+from neural_memory.utils.cjk import cjk_spaced, is_cjk_char
 from neural_memory.utils.tag_normalizer import normalize_tags_lower
 from neural_memory.utils.timeutils import utcnow
 
 
 def _build_fts_query(search_term: str) -> str:
-    """Build an FTS5 MATCH expression from a user search string."""
-    tokens = search_term.split()
-    if not tokens:
+    """Build an FTS5 MATCH expression from a user search string.
+
+    Splits on whitespace, quotes each piece to escape FTS5 operators
+    (AND, OR, NOT, NEAR, *, etc.), and joins with implicit AND.
+    CJK runs are spaced (see utils/cjk.py) and quoted as a phrase so
+    Chinese short words match the cjk_spaced() index.
+    """
+    terms = search_term.split()
+    if not terms:
         return '""'
-    return " ".join(f'"{token.replace(chr(34), chr(34) + chr(34))}"' for token in tokens)
+    parts: list[str] = []
+    for piece in terms:
+        if any(is_cjk_char(ch) for ch in piece):
+            parts.append(f'"{cjk_spaced(piece).strip()}"')
+        else:
+            parts.append(f'"{piece.replace(chr(34), chr(34) + chr(34))}"')
+    return " ".join(parts)
 
 
 if TYPE_CHECKING:

--- a/src/neural_memory/storage/sqlite_neurons.py
+++ b/src/neural_memory/storage/sqlite_neurons.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 
 from neural_memory.core.neuron import Neuron, NeuronState, NeuronType
 from neural_memory.storage.sqlite_row_mappers import row_to_neuron, row_to_neuron_state
+from neural_memory.utils.cjk import cjk_spaced, is_cjk_char
 from neural_memory.utils.timeutils import utcnow
 
 if TYPE_CHECKING:
@@ -22,32 +23,43 @@ logger = logging.getLogger(__name__)
 def _build_fts_query(search_term: str) -> str:
     """Build an FTS5 MATCH expression from a user search string.
 
-    Splits on whitespace, quotes each token to escape FTS5 operators
+    Splits on whitespace, quotes each piece to escape FTS5 operators
     (AND, OR, NOT, NEAR, *, etc.), and joins with implicit AND.
-    Double quotes within tokens are escaped by doubling them.
-    Example: 'API design' → '"API" "design"'
+    CJK runs are spaced (see utils/cjk.py) and quoted as a phrase so
+    Chinese short words match the cjk_spaced() index.
     """
-    tokens = search_term.split()
-    if not tokens:
+    terms = search_term.split()
+    if not terms:
         return '""'
-    return " ".join(f'"{token.replace(chr(34), chr(34) + chr(34))}"' for token in tokens)
+    parts: list[str] = []
+    for piece in terms:
+        if any(is_cjk_char(ch) for ch in piece):
+            parts.append(f'"{cjk_spaced(piece).strip()}"')
+        else:
+            parts.append(f'"{piece.replace(chr(34), chr(34) + chr(34))}"')
+    return " ".join(parts)
 
 
 def _build_fts_prefix_query(prefix: str) -> str:
-    """Build FTS5 MATCH with prefix on last token.
+    """Build FTS5 MATCH with prefix on last piece.
 
-    All tokens except the last are quoted (exact match).
-    The last token is sanitized and gets a ``*`` suffix (prefix match).
-    Example: ``'API des'`` → ``'"API" des*'``
+    All pieces except the last are quoted (exact match).
+    The last piece is sanitized and gets a ``*`` suffix (prefix match).
+    Example: ``'API des'`` -> ``'"API" des*'``
+
+    CJK queries fall back to exact phrase matching - a spaced single-char
+    piece sequence has no meaningful FTS5 prefix semantics.
     """
-    tokens = prefix.split()
-    if not tokens:
+    terms = prefix.split()
+    if not terms:
         return '""'
+    if any(is_cjk_char(ch) for piece in terms for ch in piece):
+        return _build_fts_query(prefix)
     parts: list[str] = []
-    for token in tokens[:-1]:
-        escaped = token.replace(chr(34), chr(34) + chr(34))
+    for piece in terms[0:-1]:
+        escaped = piece.replace(chr(34), chr(34) + chr(34))
         parts.append(f'"{escaped}"')
-    last = re.sub(r"[^\w]", "", tokens[-1], flags=re.UNICODE)
+    last = re.sub(r"[^\w]", "", terms[-1], flags=re.UNICODE)
     if last:
         parts.append(f"{last}*")
     return " ".join(parts) if parts else '""'

--- a/src/neural_memory/storage/sqlite_neurons.py
+++ b/src/neural_memory/storage/sqlite_neurons.py
@@ -34,7 +34,8 @@ def _build_fts_query(search_term: str) -> str:
     parts: list[str] = []
     for piece in terms:
         if any(is_cjk_char(ch) for ch in piece):
-            parts.append(f'"{(cjk_spaced(piece) or "").strip()}"')
+            escaped = piece.replace(chr(34), chr(34) + chr(34))
+            parts.append(f'"{(cjk_spaced(escaped) or "").strip()}"')
         else:
             parts.append(f'"{piece.replace(chr(34), chr(34) + chr(34))}"')
     return " ".join(parts)

--- a/src/neural_memory/storage/sqlite_neurons.py
+++ b/src/neural_memory/storage/sqlite_neurons.py
@@ -34,7 +34,7 @@ def _build_fts_query(search_term: str) -> str:
     parts: list[str] = []
     for piece in terms:
         if any(is_cjk_char(ch) for ch in piece):
-            parts.append(f'"{cjk_spaced(piece).strip()}"')
+            parts.append(f'"{(cjk_spaced(piece) or "").strip()}"')
         else:
             parts.append(f'"{piece.replace(chr(34), chr(34) + chr(34))}"')
     return " ".join(parts)

--- a/src/neural_memory/storage/sqlite_schema.py
+++ b/src/neural_memory/storage/sqlite_schema.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Schema version for migrations
-SCHEMA_VERSION = 41
+SCHEMA_VERSION = 42
 
 # â”€â”€ Migrations â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 # Each entry maps (from_version -> to_version) with a list of SQL statements.
@@ -31,22 +31,24 @@ FTS_SETUP_STATEMENTS: list[str] = [
         content_rowid='rowid',
         tokenize='porter unicode61 remove_diacritics 2'
     )""",
-    # Auto-sync: insert
+    # Auto-sync: insert — store cjk_spaced() text so unicode61 tokenizes
+    # each CJK character separately (see utils/cjk.py). The 'delete'
+    # commands below must receive the same spacing they were inserted with.
     """CREATE TRIGGER IF NOT EXISTS neurons_ai AFTER INSERT ON neurons BEGIN
         INSERT INTO neurons_fts(rowid, content, brain_id)
-        VALUES (new.rowid, new.content, new.brain_id);
+        VALUES (new.rowid, cjk_spaced(new.content), new.brain_id);
     END""",
     # Auto-sync: delete
     """CREATE TRIGGER IF NOT EXISTS neurons_ad AFTER DELETE ON neurons BEGIN
         INSERT INTO neurons_fts(neurons_fts, rowid, content, brain_id)
-        VALUES ('delete', old.rowid, old.content, old.brain_id);
+        VALUES ('delete', old.rowid, cjk_spaced(old.content), old.brain_id);
     END""",
     # Auto-sync: update
     """CREATE TRIGGER IF NOT EXISTS neurons_au AFTER UPDATE ON neurons BEGIN
         INSERT INTO neurons_fts(neurons_fts, rowid, content, brain_id)
-        VALUES ('delete', old.rowid, old.content, old.brain_id);
+        VALUES ('delete', old.rowid, cjk_spaced(old.content), old.brain_id);
         INSERT INTO neurons_fts(rowid, content, brain_id)
-        VALUES (new.rowid, new.content, new.brain_id);
+        VALUES (new.rowid, cjk_spaced(new.content), new.brain_id);
     END""",
 ]
 
@@ -59,27 +61,29 @@ FIBER_FTS_SETUP_STATEMENTS: list[str] = [
         content_rowid='rowid',
         tokenize='porter unicode61 remove_diacritics 2'
     )""",
-    # Auto-sync: insert
+    # Auto-sync: insert — store cjk_spaced() text so unicode61 tokenizes
+    # each CJK character separately (see utils/cjk.py). The 'delete'
+    # commands below must receive the same spacing they were inserted with.
     """CREATE TRIGGER IF NOT EXISTS fibers_ai AFTER INSERT ON fibers
     WHEN new.summary IS NOT NULL AND new.summary != '' BEGIN
         INSERT INTO fibers_fts(rowid, summary, brain_id)
-        VALUES (new.rowid, new.summary, new.brain_id);
+        VALUES (new.rowid, cjk_spaced(new.summary), new.brain_id);
     END""",
     # Auto-sync: delete
     """CREATE TRIGGER IF NOT EXISTS fibers_ad AFTER DELETE ON fibers
     WHEN old.summary IS NOT NULL AND old.summary != '' BEGIN
         INSERT INTO fibers_fts(fibers_fts, rowid, summary, brain_id)
-        VALUES ('delete', old.rowid, old.summary, old.brain_id);
+        VALUES ('delete', old.rowid, cjk_spaced(old.summary), old.brain_id);
     END""",
     # Auto-sync: update — handle NULL↔text both directions (P3-T3).
     # Drop/recreate in ensure_fiber_fts_tables so upgrades pick this up.
     "DROP TRIGGER IF EXISTS fibers_au",
     """CREATE TRIGGER IF NOT EXISTS fibers_au AFTER UPDATE ON fibers BEGIN
         INSERT INTO fibers_fts(fibers_fts, rowid, summary, brain_id)
-        SELECT 'delete', old.rowid, old.summary, old.brain_id
+        SELECT 'delete', old.rowid, cjk_spaced(old.summary), old.brain_id
         WHERE old.summary IS NOT NULL AND old.summary != '';
         INSERT INTO fibers_fts(rowid, summary, brain_id)
-        SELECT new.rowid, new.summary, new.brain_id
+        SELECT new.rowid, cjk_spaced(new.summary), new.brain_id
         WHERE new.summary IS NOT NULL AND new.summary != '';
     END""",
 ]
@@ -658,6 +662,23 @@ MIGRATIONS: dict[tuple[int, int], list[str]] = {
         "CREATE INDEX IF NOT EXISTS idx_consolidation_checkpoints_brain "
         "ON consolidation_checkpoints(brain_id)",
     ],
+    (41, 42): [
+        # CJK recall fix: unicode61 treats a CJK run as one token, so
+        # Chinese short-word queries ("起源", "服务器") never match content
+        # holding longer CJK phrases. The rebuilt FTS sync triggers store
+        # cjk_spaced() text (each hanzi becomes its own token) and the FTS
+        # query builders phrase the spaced tokens the same way — see
+        # utils/cjk.py. Drop both FTS tables here; run_migrations recreates
+        # them with the new triggers and backfills cjk_spaced() text.
+        "DROP TRIGGER IF EXISTS neurons_au",
+        "DROP TRIGGER IF EXISTS neurons_ad",
+        "DROP TRIGGER IF EXISTS neurons_ai",
+        "DROP TABLE IF EXISTS neurons_fts",
+        "DROP TRIGGER IF EXISTS fibers_au",
+        "DROP TRIGGER IF EXISTS fibers_ad",
+        "DROP TRIGGER IF EXISTS fibers_ai",
+        "DROP TABLE IF EXISTS fibers_fts",
+    ],
     (39, 40): [
         # Durable enrichment outbox (Phase 5) — separate from change_log.synced
         """CREATE TABLE IF NOT EXISTS enrichment_jobs (
@@ -744,6 +765,32 @@ async def run_migrations(conn: aiosqlite.Connection, current_version: int) -> in
             await conn.execute(
                 "INSERT OR IGNORE INTO fibers_fts(rowid, summary, brain_id) "
                 "SELECT rowid, summary, brain_id FROM fibers WHERE summary IS NOT NULL"
+            )
+            await conn.commit()
+            version = next_version
+            continue
+
+        # v41->v42 drops FTS tables; recreate with CJK-spaced triggers + backfill
+        if key == (41, 42):
+            statements_42 = MIGRATIONS.get(key, [])
+            for sql in statements_42:
+                try:
+                    await conn.execute(sql)
+                except Exception:
+                    pass  # triggers/tables may not exist
+            await ensure_fts_tables(conn)
+            await ensure_fiber_fts_tables(conn)
+            # Backfill with cjk_spaced() text so Chinese short-word
+            # queries hit (utils/cjk.py). Requires the cjk_spaced SQL
+            # function, registered by the storage layer before migrations.
+            await conn.execute(
+                "INSERT OR IGNORE INTO neurons_fts(rowid, content, brain_id) "
+                "SELECT rowid, cjk_spaced(content), brain_id FROM neurons"
+            )
+            await conn.execute(
+                "INSERT OR IGNORE INTO fibers_fts(rowid, summary, brain_id) "
+                "SELECT rowid, cjk_spaced(summary), brain_id FROM fibers "
+                "WHERE summary IS NOT NULL AND summary != ''"
             )
             await conn.commit()
             version = next_version

--- a/src/neural_memory/storage/sqlite_schema.py
+++ b/src/neural_memory/storage/sqlite_schema.py
@@ -778,20 +778,32 @@ async def run_migrations(conn: aiosqlite.Connection, current_version: int) -> in
                     await conn.execute(sql)
                 except Exception:
                     pass  # triggers/tables may not exist
-            await ensure_fts_tables(conn)
-            await ensure_fiber_fts_tables(conn)
-            # Backfill with cjk_spaced() text so Chinese short-word
-            # queries hit (utils/cjk.py). Requires the cjk_spaced SQL
-            # function, registered by the storage layer before migrations.
-            await conn.execute(
-                "INSERT OR IGNORE INTO neurons_fts(rowid, content, brain_id) "
-                "SELECT rowid, cjk_spaced(content), brain_id FROM neurons"
+            # Rebuild each FTS layer only when its content table exists.
+            # Real v41 databases always have neurons/fibers; bare/minimal
+            # test databases (migration unit tests) may not, and the sync
+            # triggers cannot be created without the content table.
+            has_neurons = await conn.execute_fetchall(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='neurons'"
             )
-            await conn.execute(
-                "INSERT OR IGNORE INTO fibers_fts(rowid, summary, brain_id) "
-                "SELECT rowid, cjk_spaced(summary), brain_id FROM fibers "
-                "WHERE summary IS NOT NULL AND summary != ''"
+            has_fibers = await conn.execute_fetchall(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='fibers'"
             )
+            if has_neurons:
+                await ensure_fts_tables(conn)
+                # Backfill with cjk_spaced() text so Chinese short-word
+                # queries hit (utils/cjk.py). Requires the cjk_spaced SQL
+                # function, registered by the storage layer before migrations.
+                await conn.execute(
+                    "INSERT OR IGNORE INTO neurons_fts(rowid, content, brain_id) "
+                    "SELECT rowid, cjk_spaced(content), brain_id FROM neurons"
+                )
+            if has_fibers:
+                await ensure_fiber_fts_tables(conn)
+                await conn.execute(
+                    "INSERT OR IGNORE INTO fibers_fts(rowid, summary, brain_id) "
+                    "SELECT rowid, cjk_spaced(summary), brain_id FROM fibers "
+                    "WHERE summary IS NOT NULL AND summary != ''"
+                )
             await conn.commit()
             version = next_version
             continue

--- a/src/neural_memory/storage/sqlite_schema.py
+++ b/src/neural_memory/storage/sqlite_schema.py
@@ -774,10 +774,8 @@ async def run_migrations(conn: aiosqlite.Connection, current_version: int) -> in
         if key == (41, 42):
             statements_42 = MIGRATIONS.get(key, [])
             for sql in statements_42:
-                try:
-                    await conn.execute(sql)
-                except Exception:
-                    pass  # triggers/tables may not exist
+                # DROP ... IF EXISTS is idempotent; real failures propagate.
+                await conn.execute(sql)
             # Rebuild each FTS layer only when its content table exists.
             # Real v41 databases always have neurons/fibers; bare/minimal
             # test databases (migration unit tests) may not, and the sync

--- a/src/neural_memory/storage/sqlite_store.py
+++ b/src/neural_memory/storage/sqlite_store.py
@@ -57,6 +57,7 @@ from neural_memory.storage.sqlite_tool_events import SQLiteToolEventsMixin
 from neural_memory.storage.sqlite_training_files import SQLiteTrainingFilesMixin
 from neural_memory.storage.sqlite_typed import SQLiteTypedMemoryMixin
 from neural_memory.storage.sqlite_versioning import SQLiteVersioningMixin
+from neural_memory.utils.cjk import cjk_spaced
 
 logger = logging.getLogger(__name__)
 
@@ -136,6 +137,11 @@ class SQLiteStorage(
 
         self._conn = await aiosqlite.connect(self._db_path)
         self._conn.row_factory = aiosqlite.Row
+
+        # FTS sync triggers call cjk_spaced() so the index stores
+        # CJK-spaced text (see utils/cjk.py). Must be registered before
+        # any write or migration touches the FTS tables.
+        await self._conn.create_function("cjk_spaced", 1, cjk_spaced)
 
         await self._conn.execute("PRAGMA foreign_keys = ON")
         await self._conn.execute("PRAGMA journal_mode=WAL")

--- a/src/neural_memory/storage/sqlite_store.py
+++ b/src/neural_memory/storage/sqlite_store.py
@@ -159,6 +159,17 @@ class SQLiteStorage(
         async with self._conn.execute("SELECT version FROM schema_version") as cursor:
             row = await cursor.fetchone()
 
+        # A database created by a newer release must not be opened by
+        # this one: its FTS triggers may call functions we do not register
+        # (e.g. cjk_spaced after schema v42), failing only on the first
+        # write with a confusing error. Fail fast instead.
+        if row is not None and row["version"] > SCHEMA_VERSION:
+            raise RuntimeError(
+                f"Database schema version {row['version']} is newer than this "
+                f"package ({SCHEMA_VERSION}). Upgrade neural-memory or "
+                "restore an older DB."
+            )
+
         if row is not None and row["version"] < SCHEMA_VERSION:
             await run_migrations(self._conn, row["version"])
 

--- a/src/neural_memory/utils/cjk.py
+++ b/src/neural_memory/utils/cjk.py
@@ -1,0 +1,57 @@
+"""CJK-aware text helpers for FTS5 tokenization.
+
+SQLite's ``unicode61`` tokenizer treats a run of CJK characters as a
+single token, so an exact query like ``"起源"`` never matches content
+``"起源世界"`` — both are one token and FTS5 exact-match does not
+substring-match. Inserting spaces between CJK characters makes each
+hanzi its own token, and quoting the spaced query as an FTS5 phrase
+(``"起 源"``) restores substring-like matching for Chinese short words.
+
+Used on both sides of the FTS pipeline:
+
+- write path: the FTS sync triggers call the registered ``cjk_spaced``
+  SQL function so the index stores spaced text (including the
+  ``'delete'`` command, which must receive the same tokenization it was
+  inserted with);
+- read path: the FTS query builders apply the same spacing so the query
+  phrase lines up with the indexed token sequence.
+"""
+
+from __future__ import annotations
+
+# CJK ideograph blocks relevant for Chinese text (extension A + unified +
+# compatibility). Python's str.isalpha() also covers CJK, but an explicit
+# range check keeps the helper dependency-free and predictable.
+_CJK_RANGES: tuple[tuple[int, int], ...] = (
+    (0x3400, 0x4DBF),  # CJK Unified Ideographs Extension A
+    (0x4E00, 0x9FFF),  # CJK Unified Ideographs
+    (0xF900, 0xFAFF),  # CJK Compatibility Ideographs
+)
+
+
+def is_cjk_char(ch: str) -> bool:
+    """Return True if *ch* is a single CJK ideograph."""
+    if len(ch) != 1:
+        return False
+    cp = ord(ch)
+    return any(lo <= cp <= hi for lo, hi in _CJK_RANGES)
+
+
+def cjk_spaced(text: str | None) -> str | None:
+    """Insert spaces around CJK characters so unicode61 tokenizes each hanzi separately.
+
+    Non-CJK runs (latin, digits, whitespace) are preserved verbatim.
+    ``None`` passes through untouched so the SQL function can be used on
+    nullable columns (e.g. ``fibers.summary``).
+    """
+    if not text:
+        return text
+    out: list[str] = []
+    for ch in text:
+        if is_cjk_char(ch):
+            out.append(" ")
+            out.append(ch)
+            out.append(" ")
+        else:
+            out.append(ch)
+    return "".join(out)

--- a/src/neural_memory/utils/cjk.py
+++ b/src/neural_memory/utils/cjk.py
@@ -26,6 +26,12 @@ _CJK_RANGES: tuple[tuple[int, int], ...] = (
     (0x3400, 0x4DBF),  # CJK Unified Ideographs Extension A
     (0x4E00, 0x9FFF),  # CJK Unified Ideographs
     (0xF900, 0xFAFF),  # CJK Compatibility Ideographs
+    (0x20000, 0x2A6DF),  # Extension B
+    (0x2A700, 0x2B73F),  # Extension C
+    (0x2B740, 0x2B81F),  # Extension D
+    (0x2B820, 0x2CEAF),  # Extension E
+    (0x2CEB0, 0x2EBEF),  # Extension F
+    (0x30000, 0x3134F),  # Extension G
 )
 
 

--- a/tests/integration/test_chinese_fts_recall.py
+++ b/tests/integration/test_chinese_fts_recall.py
@@ -80,6 +80,13 @@ async def test_chinese_delete_removes_fts(store: SQLStorage) -> None:
     assert all(h.id != n.id for h in hits)
 
 
+async def test_chinese_query_with_quote_does_not_crash(store: SQLStorage) -> None:
+    await store.add_neuron(Neuron.create(type=NeuronType.CONCEPT, content="起源世界与太古文明"))
+    # A quote mixed into a CJK query must be escaped, not break FTS5 parsing.
+    hits = await store.find_neurons(content_contains='起源" OR *', limit=10)
+    assert isinstance(hits, list)
+
+
 async def test_migration_v41_v42_backfills_cjk_index(tmp_path: Path) -> None:
     """A v41 database with raw (unspaced) FTS data is reindexed on upgrade."""
     db = tmp_path / "mig.db"

--- a/tests/integration/test_chinese_fts_recall.py
+++ b/tests/integration/test_chinese_fts_recall.py
@@ -1,0 +1,127 @@
+"""Chinese recall through the real SQLStorage + FTS5 pipeline.
+
+Verifies that CJK short-word queries hit via the cjk_spaced() index
+(utils/cjk.py) end-to-end: insert, update, delete, fiber summaries,
+and the v41 -> v42 migration backfill.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from neural_memory.core.brain import Brain
+from neural_memory.core.fiber import Fiber
+from neural_memory.core.neuron import Neuron, NeuronType
+from neural_memory.storage.sql.sql_storage import SQLStorage
+from neural_memory.storage.sql.sqlite_dialect import SQLiteDialect
+
+
+@pytest.fixture
+async def store(tmp_path: Path):
+    s = SQLStorage(SQLiteDialect(tmp_path / "zh.db"))
+    await s.initialize()
+    brain = Brain.create(name="zh")
+    await s.save_brain(brain)
+    s.set_brain(brain.id)
+    yield s
+    await s.close()
+
+
+async def test_chinese_neuron_short_word_hits(store: SQLStorage) -> None:
+    await store.add_neuron(
+        Neuron.create(type=NeuronType.CONCEPT, content="起源世界与太古文明和太空电梯")
+    )
+    hits = await store.find_neurons(content_contains="起源", limit=10)
+    assert any("起源" in n.content for n in hits)
+    hits2 = await store.find_neurons(content_contains="电梯", limit=10)
+    assert any("电梯" in n.content for n in hits2)
+
+
+async def test_chinese_mixed_latin_neuron(store: SQLStorage) -> None:
+    await store.add_neuron(Neuron.create(type=NeuronType.CONCEPT, content="服务器配置 v2rayN 代理"))
+    hits = await store.find_neurons(content_contains="代理", limit=10)
+    assert any("代理" in n.content for n in hits)
+    hits2 = await store.find_neurons(content_contains="v2rayN代理", limit=10)
+    assert any("v2rayN" in n.content for n in hits2)
+
+
+async def test_chinese_fiber_summary_hits(store: SQLStorage) -> None:
+    n = Neuron.create(type=NeuronType.CONCEPT, content="anchor fiber")
+    await store.add_neuron(n)
+    fiber = Fiber.create(
+        neuron_ids={n.id},
+        synapse_ids=set(),
+        anchor_neuron_id=n.id,
+        summary="起源设定共工怒触不周山",
+    )
+    await store.add_fiber(fiber)
+    hits = await store.search_fiber_summaries("不周山", limit=10)
+    assert any(f.id == fiber.id for f in hits)
+
+
+async def test_chinese_update_replaces_fts_terms(store: SQLStorage) -> None:
+    n = Neuron.create(type=NeuronType.CONCEPT, content="旧词太阳")
+    await store.add_neuron(n)
+    await store.update_neuron(replace(n, content="新词月亮"))
+    old = await store.find_neurons(content_contains="太阳", limit=10)
+    new = await store.find_neurons(content_contains="月亮", limit=10)
+    assert all(h.id != n.id for h in old)
+    assert any(h.id == n.id for h in new)
+
+
+async def test_chinese_delete_removes_fts(store: SQLStorage) -> None:
+    n = Neuron.create(type=NeuronType.CONCEPT, content="待删彩虹")
+    await store.add_neuron(n)
+    assert await store.delete_neuron(n.id)
+    hits = await store.find_neurons(content_contains="彩虹", limit=10)
+    assert all(h.id != n.id for h in hits)
+
+
+async def test_migration_v41_v42_backfills_cjk_index(tmp_path: Path) -> None:
+    """A v41 database with raw (unspaced) FTS data is reindexed on upgrade."""
+    db = tmp_path / "mig.db"
+
+    # 1) Build a current-schema database, then rewind it to v41 and strip
+    #    the FTS layer to simulate a pre-fix database.
+    s = SQLStorage(SQLiteDialect(db))
+    await s.initialize()
+    brain = Brain.create(name="mig")
+    await s.save_brain(brain)
+    s.set_brain(brain.id)
+    # Insert a Chinese neuron while the new triggers are still active, then
+    # drop the whole FTS layer so the old DB state has no index at all.
+    n = Neuron.create(type=NeuronType.CONCEPT, content="迁移验证海底两万里")
+    await store_add(s, n)
+    await s.close()
+
+    import sqlite3
+
+    conn = sqlite3.connect(db)
+    conn.execute("DROP TRIGGER IF EXISTS neurons_au")
+    conn.execute("DROP TRIGGER IF EXISTS neurons_ad")
+    conn.execute("DROP TRIGGER IF EXISTS neurons_ai")
+    conn.execute("DROP TRIGGER IF EXISTS fibers_au")
+    conn.execute("DROP TRIGGER IF EXISTS fibers_ad")
+    conn.execute("DROP TRIGGER IF EXISTS fibers_ai")
+    conn.execute("DROP TABLE IF EXISTS neurons_fts")
+    conn.execute("DROP TABLE IF EXISTS fibers_fts")
+    conn.execute("UPDATE schema_version SET version = 41")
+    conn.commit()
+    conn.close()
+
+    # 2) Reopen: the 41 -> 42 migration must rebuild the FTS tables with
+    #    cjk_spaced() triggers and backfill existing rows.
+    s2 = SQLStorage(SQLiteDialect(db))
+    await s2.initialize()
+    brain2 = await s2.get_brain(brain.id)
+    s2.set_brain(brain2.id)
+    hits = await s2.find_neurons(content_contains="海底", limit=10)
+    assert any("海底" in x.content for x in hits)
+    await s2.close()
+
+
+async def store_add(store: SQLStorage, neuron: Neuron) -> None:
+    await store.add_neuron(neuron)

--- a/tests/integration/test_consolidation_checkpoint_migration.py
+++ b/tests/integration/test_consolidation_checkpoint_migration.py
@@ -28,7 +28,7 @@ async def storage(tmp_path: Path) -> SQLStorage:
 @pytest.mark.asyncio
 async def test_schema_version_41(storage: SQLStorage) -> None:
     row = await storage._dialect.fetch_one("SELECT version FROM schema_version")
-    assert int(row["version"]) == SCHEMA_VERSION == 41
+    assert int(row["version"]) == SCHEMA_VERSION == 42
 
 
 @pytest.mark.asyncio
@@ -45,7 +45,7 @@ async def test_migrate_40_to_41(tmp_path: Path) -> None:
         )
         await conn.commit()
         final = await run_migrations(conn, 40)
-        assert final == 41
+        assert final == 42
         cur = await conn.execute(
             "SELECT name FROM sqlite_master WHERE type='table' AND name='consolidation_checkpoints'"
         )

--- a/tests/integration/test_enrichment_outbox.py
+++ b/tests/integration/test_enrichment_outbox.py
@@ -31,7 +31,7 @@ async def storage(tmp_path: Path) -> SQLStorage:
 async def test_schema_version_is_40(storage: SQLStorage) -> None:
     row = await storage._dialect.fetch_one("SELECT version FROM schema_version")
     assert row is not None
-    assert int(row["version"]) == SCHEMA_VERSION == 41
+    assert int(row["version"]) == SCHEMA_VERSION == 42
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_enrichment_outbox_migrations.py
+++ b/tests/integration/test_enrichment_outbox_migrations.py
@@ -26,7 +26,7 @@ async def test_migrate_39_to_40(tmp_path: Path) -> None:
         await conn.commit()
 
         final = await run_migrations(conn, 39)
-        assert final == SCHEMA_VERSION == 41
+        assert final == SCHEMA_VERSION == 42
 
         row = await conn.execute(
             "SELECT name FROM sqlite_master WHERE type='table' AND name='enrichment_jobs'"
@@ -52,7 +52,7 @@ async def test_fresh_install_has_enrichment_jobs(tmp_path: Path) -> None:
     )
     assert row is not None
     ver = await store._dialect.fetch_one("SELECT version FROM schema_version")
-    assert int(ver["version"]) == 41
+    assert int(ver["version"]) == 42
     await store.close()
 
 
@@ -69,5 +69,5 @@ async def test_already_migrated_noop(tmp_path: Path) -> None:
     store2 = SQLStorage(SQLiteDialect(path))
     await store2.initialize()  # must not raise
     ver = await store2._dialect.fetch_one("SELECT version FROM schema_version")
-    assert int(ver["version"]) == 41
+    assert int(ver["version"]) == 42
     await store2.close()

--- a/tests/unit/test_baby_mi_features.py
+++ b/tests/unit/test_baby_mi_features.py
@@ -366,7 +366,7 @@ class TestTrustScore:
     """Trust score field on TypedMemory."""
 
     def test_schema_version_25(self):
-        assert SCHEMA_VERSION == 41
+        assert SCHEMA_VERSION == 42
 
     def test_trust_score_field_on_typed_memory(self):
         tm = TypedMemory.create(

--- a/tests/unit/test_cascading_retrieval.py
+++ b/tests/unit/test_cascading_retrieval.py
@@ -214,7 +214,7 @@ class TestSchemaV27:
         """Schema version bumped to 27."""
         from neural_memory.storage.sqlite_schema import SCHEMA_VERSION
 
-        assert SCHEMA_VERSION == 41
+        assert SCHEMA_VERSION == 42
 
     @pytest.mark.asyncio
     async def test_fiber_fts_table_exists(self, storage: SQLiteStorage) -> None:

--- a/tests/unit/test_cjk_fts.py
+++ b/tests/unit/test_cjk_fts.py
@@ -40,6 +40,11 @@ class TestIsCjkChar:
     def test_multi_char_string_false(self) -> None:
         assert not is_cjk_char("起源")
 
+    def test_extension_b_hanzi_true(self) -> None:
+        assert is_cjk_char(chr(0x20000))
+        assert is_cjk_char(chr(0x2A6DF))
+        assert not is_cjk_char(chr(0x2A6E0))
+
 
 class TestBuildFtsQuery:
     def test_english_unchanged(self) -> None:
@@ -56,6 +61,11 @@ class TestBuildFtsQuery:
 
     def test_empty(self) -> None:
         assert _build_fts_query("") == '""'
+
+    def test_chinese_with_double_quote_escaped(self) -> None:
+        # Quotes inside a CJK piece must be doubled like the non-CJK
+        # branch, otherwise the FTS5 phrase is unterminated.
+        assert _build_fts_query('起源" OR *') == '"起  源 """ "OR" "*"'
 
 
 class TestBuildFtsPrefixQuery:

--- a/tests/unit/test_cjk_fts.py
+++ b/tests/unit/test_cjk_fts.py
@@ -1,0 +1,69 @@
+"""Unit tests for CJK FTS helpers and query builders.
+
+Covers utils/cjk.py (cjk_spaced / is_cjk_char) and the CJK-aware FTS5
+MATCH expression builders shared by the SQLite storage paths.
+"""
+
+from __future__ import annotations
+
+from neural_memory.storage.sql.mixins.fibers import _build_fts_query
+from neural_memory.storage.sql.mixins.neurons import _build_fts_prefix_query
+from neural_memory.utils.cjk import cjk_spaced, is_cjk_char
+
+
+class TestCjkSpaced:
+    def test_cjk_characters_get_spaced(self) -> None:
+        assert cjk_spaced("起源世界") == " 起  源  世  界 "
+
+    def test_latin_preserved(self) -> None:
+        assert cjk_spaced("v2rayN") == "v2rayN"
+
+    def test_mixed_cjk_latin(self) -> None:
+        assert cjk_spaced("v2rayN代理") == "v2rayN 代  理 "
+
+    def test_none_passthrough(self) -> None:
+        assert cjk_spaced(None) is None
+
+    def test_empty_string(self) -> None:
+        assert cjk_spaced("") == ""
+
+
+class TestIsCjkChar:
+    def test_hanzi_true(self) -> None:
+        assert is_cjk_char("起")
+        assert is_cjk_char("世")
+
+    def test_latin_and_digits_false(self) -> None:
+        assert not is_cjk_char("a")
+        assert not is_cjk_char("1")
+
+    def test_multi_char_string_false(self) -> None:
+        assert not is_cjk_char("起源")
+
+
+class TestBuildFtsQuery:
+    def test_english_unchanged(self) -> None:
+        assert _build_fts_query("API design") == '"API" "design"'
+
+    def test_chinese_short_word_phrased(self) -> None:
+        assert _build_fts_query("起源") == '"起  源"'
+
+    def test_chinese_multi_term(self) -> None:
+        assert _build_fts_query("世界 电梯") == '"世  界" "电  梯"'
+
+    def test_mixed_cjk_latin(self) -> None:
+        assert _build_fts_query("v2rayN代理") == '"v2rayN 代  理"'
+
+    def test_empty(self) -> None:
+        assert _build_fts_query("") == '""'
+
+
+class TestBuildFtsPrefixQuery:
+    def test_english_prefix_unchanged(self) -> None:
+        assert _build_fts_prefix_query("API des") == '"API" des*'
+
+    def test_chinese_falls_back_to_phrase(self) -> None:
+        assert _build_fts_prefix_query("起源") == '"起  源"'
+
+    def test_chinese_multi_terms_fallback(self) -> None:
+        assert _build_fts_prefix_query("世界 电梯") == '"世  界" "电  梯"'

--- a/tests/unit/test_ephemeral.py
+++ b/tests/unit/test_ephemeral.py
@@ -22,7 +22,7 @@ from neural_memory.utils.timeutils import utcnow
 
 class TestSchemaVersion:
     def test_schema_version_is_33(self) -> None:
-        assert SCHEMA_VERSION == 41
+        assert SCHEMA_VERSION == 42
 
 
 # ── Neuron dataclass ────────────────────────────────────────────────

--- a/tests/unit/test_source_registry.py
+++ b/tests/unit/test_source_registry.py
@@ -102,7 +102,7 @@ class TestSchemaMigrationV23:
     def test_schema_version_is_25(self) -> None:
         from neural_memory.storage.sqlite_schema import SCHEMA_VERSION
 
-        assert SCHEMA_VERSION == 41
+        assert SCHEMA_VERSION == 42
 
     def test_migration_22_23_exists(self) -> None:
         from neural_memory.storage.sqlite_schema import MIGRATIONS

--- a/tests/unit/test_tiered_memory_phase1.py
+++ b/tests/unit/test_tiered_memory_phase1.py
@@ -164,7 +164,7 @@ class TestSchemaMigration:
     def test_migration_exists(self) -> None:
         from neural_memory.storage.sqlite_schema import MIGRATIONS, SCHEMA_VERSION
 
-        assert SCHEMA_VERSION == 41
+        assert SCHEMA_VERSION == 42
         assert (36, 37) in MIGRATIONS
         assert (37, 38) in MIGRATIONS
         stmts = MIGRATIONS[(36, 37)]


### PR DESCRIPTION
## Summary

SQLite's unicode61 segmentation treats a contiguous CJK run as one indexed term, so exact Chinese short-word queries (起源, 服务器) never matched content holding longer CJK phrases. This PR makes Chinese short-word recall work by spacing CJK characters before indexing (each hanzi becomes its own term) and phrasing queries the same way, with a schema migration that rebuilds and backfills the existing FTS index.

**Breaking change for SQLite databases**: the v41→v42 migration is one-way. After upgrade, older releases cannot open the database for writes — their connections do not register the `cjk_spaced` SQL function that the new FTS sync triggers call, so writes fail with `no such function`. PostgreSQL backends are unaffected (ILIKE path, no FTS changes). Non-CJK recall behavior is unchanged.

## Changes

- **New `utils/cjk.py`**: `cjk_spaced()` inserts spaces around CJK ideographs so unicode61 indexes each hanzi separately; `is_cjk_char()` covers the CJK unified/compat blocks.
- **FTS sync triggers** (`storage/sqlite_schema.py`): `neurons_fts` and `fibers_fts` insert/update/delete triggers now store `cjk_spaced()` text, keeping the `'delete'` command consistent with the inserted segmentation.
- **Query builders** (`storage/sql/mixins/fibers.py`, `storage/sql/mixins/neurons.py`, legacy `storage/sqlite_fibers.py`, `storage/sqlite_neurons.py`): CJK terms are spaced and quoted as FTS5 phrases (`"起 源"`); prefix queries on CJK fall back to exact phrase matching. Non-CJK behavior is unchanged.
- **SQL function registration**: `cjk_spaced` is registered on the SQLite connections in `SQLiteDialect` and legacy `SQLiteStorage`, so the triggers and the migration backfill can call it.
- **Migration v41→v42**: drops both FTS tables, recreates them with the new triggers, and backfills `cjk_spaced()` text for existing rows.
- **CHANGELOG**: entry under `[Unreleased]`.

## Type of Change

- [x] Bug fix (fixes the Chinese short-word recall miss)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (one-way SQLite schema migration; older releases cannot write upgraded databases)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Tests

## Testing

- `ruff check` and `ruff format` clean on all changed files.
- `mypy src/ --ignore-missing-imports`: clean (453 files).
- `pytest` full suite: 7334 passed locally; CI is green on all 7 jobs (Lint, Docs Freshness, Type Check, Test 3.11, Test 3.12, Security Scan, Build Package).
- 16 new unit tests (CJK helpers + query builders) and 6 new integration tests (real SQLStorage pipeline including the v41→v42 migration backfill).
- E2E on a copy of a real memory DB: pre-migration Chinese queries missed (偏好 had 0 hits); post-migration all sampled words hit with accurate results (偏好 3, 起源 5, 服务器 5, 翻译 5, 设置 5, 代理 5).

## Checklist

- [x] Updated docs or comments as needed (CHANGELOG entry)
- [x] Added or updated tests where relevant
- [x] Migration path covered for existing databases
- [x] Non-CJK recall behavior verified unchanged by existing suites